### PR TITLE
Adds placeholder option for cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ class App extends React.Component {
       <ReactDataSheet 
         data={this.state.grid}
         valueRenderer={(cell) => cell.value}
-        onChange={(cell, colI, rowJ, value, placeholder) => 
+        onChange={(cell, colI, rowJ, value) => 
           this.setState({
             grid: this.state.grid.map((col) => 
               col.map((rowCell) => 
-                (rowCell == cell) ? ({value: value, placeholder: placeholder}) : rowCell
+                (rowCell == cell) ? ({value: value}) : rowCell
               )
             )
           }) 
@@ -115,7 +115,7 @@ Option | Type | Description
 data | Array | Array of rows and each row should contain the cell objects to display
 valueRenderer | func | Method to render the value of the cell `function(cell, i, j)`. This is visible by default
 dataRenderer | func | Method to render the underlying value of the cell `function(cell, i, j)`. This data is visible once in edit mode.
-onChange | func | onChange handler: `function(cell, i, j, newValue, placeholder) {}`
+onChange | func | onChange handler: `function(cell, i, j, newValue) {}`
 onPaste | func | onPaste handler: `function(array) {}` If set, the function will be called with an array of rows. Each row has an array of objects containing the cell and raw pasted value. If the pasted value cannot be matched with a cell, the cell value will be undefined
 onContextMenu | func | Context menu handler : `function(event, cell, i, j)`
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ class App extends React.Component {
       <ReactDataSheet 
         data={this.state.grid}
         valueRenderer={(cell) => cell.value}
-        onChange={(cell, colI, rowJ, value) => 
+        onChange={(cell, colI, rowJ, value, placeholder) => 
           this.setState({
             grid: this.state.grid.map((col) => 
               col.map((rowCell) => 
-                (rowCell == cell) ? ({value: value}) : rowCell
+                (rowCell == cell) ? ({value: value, placeholder: placeholder}) : rowCell
               )
             )
           }) 
@@ -115,7 +115,7 @@ Option | Type | Description
 data | Array | Array of rows and each row should contain the cell objects to display
 valueRenderer | func | Method to render the value of the cell `function(cell, i, j)`. This is visible by default
 dataRenderer | func | Method to render the underlying value of the cell `function(cell, i, j)`. This data is visible once in edit mode.
-onChange | func | onChange handler: `function(cell, i, j, newValue) {}`
+onChange | func | onChange handler: `function(cell, i, j, newValue, placeholder) {}`
 onPaste | func | onPaste handler: `function(array) {}` If set, the function will be called with an array of rows. Each row has an array of objects containing the cell and raw pasted value. If the pasted value cannot be matched with a cell, the cell value will be undefined
 onContextMenu | func | Context menu handler : `function(event, cell, i, j)`
 
@@ -133,3 +133,4 @@ forceComponent | bool | false | Renders what's in component at all times, even w
 disableEvents | bool | false | Makes cell unselectable and read only
 colSpan | number | 1 | The colSpan of the cell's td element
 rowSpan | number | 1 | The rowSpan of the cell's td element
+placeholder | string | undefined | The placeholder text of the cell without a value

--- a/lib/DataCell.js
+++ b/lib/DataCell.js
@@ -70,7 +70,7 @@ var DataCell = function (_PureComponent) {
     key: 'onChange',
     value: function onChange(value) {
       var initialData = this.props.data === null ? this.props.value : this.props.data;
-      (value === '' || initialData !== value) && this.props.onChange(this.props.row, this.props.col, value, this.props.placeholder);
+      (value === '' || initialData !== value) && this.props.onChange(this.props.row, this.props.col, value);
     }
   }, {
     key: 'render',
@@ -122,12 +122,9 @@ var DataCell = function (_PureComponent) {
             placeholder
           ) : value
         ),
-        _react2.default.createElement('input', {
-          style: { display: editing && selected ? 'block' : 'none' },
-          ref: function ref(input) {
+        _react2.default.createElement('input', { style: { display: editing && selected ? 'block' : 'none' }, ref: function ref(input) {
             return _this3._input = input;
-          }
-        })
+          } })
       );
     }
   }]);

--- a/lib/DataCell.js
+++ b/lib/DataCell.js
@@ -70,7 +70,7 @@ var DataCell = function (_PureComponent) {
     key: 'onChange',
     value: function onChange(value) {
       var initialData = this.props.data === null ? this.props.value : this.props.data;
-      (value === '' || initialData !== value) && this.props.onChange(this.props.row, this.props.col, value);
+      (value === '' || initialData !== value) && this.props.onChange(this.props.row, this.props.col, value, this.props.placeholder);
     }
   }, {
     key: 'render',
@@ -84,6 +84,7 @@ var DataCell = function (_PureComponent) {
           readOnly = _props.readOnly,
           colSpan = _props.colSpan,
           value = _props.value,
+          placeholder = _props.placeholder,
           className = _props.className,
           editing = _props.editing,
           selected = _props.selected,
@@ -111,16 +112,22 @@ var DataCell = function (_PureComponent) {
             return _onContextMenu(e, row, col);
           },
           colSpan: colSpan || 1,
-          rowSpan: rowSpan || 1
-        },
+          rowSpan: rowSpan || 1 },
         _react2.default.createElement(
           'span',
           { style: { display: editing && selected ? 'none' : 'block' } },
-          value
+          !value && placeholder ? _react2.default.createElement(
+            'span',
+            { className: 'placeholder' },
+            placeholder
+          ) : value
         ),
-        _react2.default.createElement('input', { style: { display: editing && selected ? 'block' : 'none' }, ref: function ref(input) {
+        _react2.default.createElement('input', {
+          style: { display: editing && selected ? 'block' : 'none' },
+          ref: function ref(input) {
             return _this3._input = input;
-          } })
+          }
+        })
       );
     }
   }]);

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -237,12 +237,12 @@ var DataSheet = function (_PureComponent) {
       var lettersPressed = e.keyCode >= 65 && e.keyCode <= 90;
       var numPadKeysPressed = e.keyCode >= 96 && e.keyCode <= 105;
       var cell = data[start.i][start.j];
-      var equationKeysPressed = [187, /* equal */
-      189, /* substract */
-      190, /* period */
-      107, /* add */
-      109, /* decimal point */
-      110].indexOf(e.keyCode) > -1;
+      var equationKeysPressed = [187 /* equal */
+      , 189 /* substract */
+      , 190 /* period */
+      , 107 /* add */
+      , 109 /* decimal point */
+      , 110].indexOf(e.keyCode) > -1;
 
       if (noCellsSelected || ctrlKeyPressed || this.handleKeyboardCellMovement(e)) {
         return true;
@@ -261,7 +261,12 @@ var DataSheet = function (_PureComponent) {
       } else if (escapeKeyPressed && isEditing) {
         this.setState({ editing: {}, reverting: editing });
       } else if (enterKeyPressed && !isEditing && !cell.readOnly) {
-        this.setState({ editing: start, clear: {}, reverting: {}, forceEdit: true });
+        this.setState({
+          editing: start,
+          clear: {},
+          reverting: {},
+          forceEdit: true
+        });
       } else if (numbersPressed || numPadKeysPressed || lettersPressed || equationKeysPressed || enterKeyPressed) {
         //empty out cell if user starts typing without pressing enter
         if (!isEditing && !cell.readOnly) {
@@ -292,7 +297,13 @@ var DataSheet = function (_PureComponent) {
     key: 'onMouseDown',
     value: function onMouseDown(i, j) {
       var editing = isEmpty(this.state.editing) || this.state.editing.i !== i || this.state.editing.j !== j ? {} : this.state.editing;
-      this.setState({ selecting: true, start: { i: i, j: j }, end: { i: i, j: j }, editing: editing, forceEdit: false });
+      this.setState({
+        selecting: true,
+        start: { i: i, j: j },
+        end: { i: i, j: j },
+        editing: editing,
+        forceEdit: false
+      });
 
       //Keep listening to mouse if user releases the mouse (dragging outside)
       document.addEventListener('mouseup', this.onMouseUp);
@@ -318,8 +329,8 @@ var DataSheet = function (_PureComponent) {
     }
   }, {
     key: 'onChange',
-    value: function onChange(i, j, val) {
-      this.props.onChange(this.props.data[i][j], i, j, val);
+    value: function onChange(i, j, val, placeholder) {
+      this.props.onChange(this.props.data[i][j], i, j, val, placeholder);
       this.setState({ editing: {} });
     }
   }, {
@@ -364,9 +375,11 @@ var DataSheet = function (_PureComponent) {
 
       return _react2.default.createElement(
         'table',
-        { ref: function ref(r) {
+        {
+          ref: function ref(r) {
             return _this4.dgDom = r;
-          }, className: 'data-grid ' + (className ? className : '') },
+          },
+          className: 'data-grid ' + (className ? className : '') },
         _react2.default.createElement(
           'tbody',
           null,
@@ -388,7 +401,8 @@ var DataSheet = function (_PureComponent) {
                   editing: isEditing(i, j),
                   reverting: isReverting(i, j),
                   colSpan: cell.colSpan,
-                  value: valueRenderer(cell, i, j)
+                  value: valueRenderer(cell, i, j),
+                  placeholder: cell.placeholder
                 };
                 if (cell.component) {
                   return _react2.default.createElement(_ComponentCell2.default, _extends({}, props, {

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -237,12 +237,12 @@ var DataSheet = function (_PureComponent) {
       var lettersPressed = e.keyCode >= 65 && e.keyCode <= 90;
       var numPadKeysPressed = e.keyCode >= 96 && e.keyCode <= 105;
       var cell = data[start.i][start.j];
-      var equationKeysPressed = [187 /* equal */
-      , 189 /* substract */
-      , 190 /* period */
-      , 107 /* add */
-      , 109 /* decimal point */
-      , 110].indexOf(e.keyCode) > -1;
+      var equationKeysPressed = [187, /* equal */
+      189, /* substract */
+      190, /* period */
+      107, /* add */
+      109, /* decimal point */
+      110].indexOf(e.keyCode) > -1;
 
       if (noCellsSelected || ctrlKeyPressed || this.handleKeyboardCellMovement(e)) {
         return true;
@@ -261,12 +261,7 @@ var DataSheet = function (_PureComponent) {
       } else if (escapeKeyPressed && isEditing) {
         this.setState({ editing: {}, reverting: editing });
       } else if (enterKeyPressed && !isEditing && !cell.readOnly) {
-        this.setState({
-          editing: start,
-          clear: {},
-          reverting: {},
-          forceEdit: true
-        });
+        this.setState({ editing: start, clear: {}, reverting: {}, forceEdit: true });
       } else if (numbersPressed || numPadKeysPressed || lettersPressed || equationKeysPressed || enterKeyPressed) {
         //empty out cell if user starts typing without pressing enter
         if (!isEditing && !cell.readOnly) {
@@ -297,13 +292,7 @@ var DataSheet = function (_PureComponent) {
     key: 'onMouseDown',
     value: function onMouseDown(i, j) {
       var editing = isEmpty(this.state.editing) || this.state.editing.i !== i || this.state.editing.j !== j ? {} : this.state.editing;
-      this.setState({
-        selecting: true,
-        start: { i: i, j: j },
-        end: { i: i, j: j },
-        editing: editing,
-        forceEdit: false
-      });
+      this.setState({ selecting: true, start: { i: i, j: j }, end: { i: i, j: j }, editing: editing, forceEdit: false });
 
       //Keep listening to mouse if user releases the mouse (dragging outside)
       document.addEventListener('mouseup', this.onMouseUp);
@@ -329,8 +318,8 @@ var DataSheet = function (_PureComponent) {
     }
   }, {
     key: 'onChange',
-    value: function onChange(i, j, val, placeholder) {
-      this.props.onChange(this.props.data[i][j], i, j, val, placeholder);
+    value: function onChange(i, j, val) {
+      this.props.onChange(this.props.data[i][j], i, j, val);
       this.setState({ editing: {} });
     }
   }, {
@@ -375,11 +364,9 @@ var DataSheet = function (_PureComponent) {
 
       return _react2.default.createElement(
         'table',
-        {
-          ref: function ref(r) {
+        { ref: function ref(r) {
             return _this4.dgDom = r;
-          },
-          className: 'data-grid ' + (className ? className : '') },
+          }, className: 'data-grid ' + (className ? className : '') },
         _react2.default.createElement(
           'tbody',
           null,

--- a/src/DataCell.js
+++ b/src/DataCell.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 export default class DataCell extends PureComponent {
@@ -34,11 +34,11 @@ export default class DataCell extends PureComponent {
 
   onChange(value) {
     const initialData = this.props.data === null ? this.props.value : this.props.data;
-    (value === '' || initialData !== value) && this.props.onChange(this.props.row, this.props.col, value);
+    (value === '' || initialData !== value) && this.props.onChange(this.props.row, this.props.col, value, this.props.placeholder);
   }
 
   render() {
-    const {row, col, rowSpan, readOnly, colSpan, value, className, editing, selected, onMouseDown, onMouseOver, onDoubleClick, onContextMenu} = this.props;
+    const {row, col, rowSpan, readOnly, colSpan, value, placeholder, className, editing, selected, onMouseDown, onMouseOver, onDoubleClick, onContextMenu} = this.props;
     return (
       <td
         className={[
@@ -54,10 +54,11 @@ export default class DataCell extends PureComponent {
         onMouseOver={()=> onMouseOver(row,col)}
         onContextMenu={(e) => onContextMenu(e, row, col)}
         colSpan={colSpan || 1}
-        rowSpan={rowSpan || 1}
-      >
-        <span style={{display: (editing && selected) ? 'none':'block'}}>
-          {value}
+        rowSpan={rowSpan || 1}>
+        <span style={{ display: editing && selected ? 'none' : 'block' }}>
+          {!value && placeholder
+            ? <span className="placeholder">{placeholder}</span>
+            : value}
         </span>
         <input style={{display: (editing && selected) ? 'block' : 'none'}} ref={(input) => this._input = input}/>
       </td>

--- a/src/DataCell.js
+++ b/src/DataCell.js
@@ -34,7 +34,7 @@ export default class DataCell extends PureComponent {
 
   onChange(value) {
     const initialData = this.props.data === null ? this.props.value : this.props.data;
-    (value === '' || initialData !== value) && this.props.onChange(this.props.row, this.props.col, value, this.props.placeholder);
+    (value === '' || initialData !== value) && this.props.onChange(this.props.row, this.props.col, value);
   }
 
   render() {

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -264,9 +264,9 @@ export default class DataSheet extends PureComponent {
     document.removeEventListener('mouseup', this.onMouseUp);
   }
 
-  onChange(i, j, val) {
-    this.props.onChange(this.props.data[i][j], i, j, val);
-    this.setState({editing: {}});
+  onChange(i, j, val, placeholder) {
+    this.props.onChange(this.props.data[i][j], i, j, val, placeholder);
+    this.setState({ editing: {} });
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -317,6 +317,7 @@ export default class DataSheet extends PureComponent {
               reverting: isReverting(i, j),
               colSpan: cell.colSpan,
               value: valueRenderer(cell, i, j),
+              placeholder: cell.placeholder
             };
             if (cell.component) {
               return <ComponentCell

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -264,8 +264,8 @@ export default class DataSheet extends PureComponent {
     document.removeEventListener('mouseup', this.onMouseUp);
   }
 
-  onChange(i, j, val, placeholder) {
-    this.props.onChange(this.props.data[i][j], i, j, val, placeholder);
+  onChange(i, j, val) {
+    this.props.onChange(this.props.data[i][j], i, j, val);
     this.setState({ editing: {} });
   }
 

--- a/test/Datasheet.js
+++ b/test/Datasheet.js
@@ -87,6 +87,50 @@ describe('Component', () => {
         wrapper.unmount();
       })
 
+      it('should properly render a placeholder', () => {
+        const onMouseDown = sinon.spy();
+        const onMouseOver = sinon.spy();
+        const onDoubleClick = sinon.spy();
+        const onContextMenu = sinon.spy();
+        const wrapper = shallow(
+          <DataCell
+            row={2}
+            col={3}
+            rowSpan={4}
+            colSpan={5}
+            placeholder={'test'}
+            className={'test'}
+            editing={false}
+            selected={false}
+            onMouseDown={onMouseDown}
+            onDoubleClick={onDoubleClick}
+            onMouseOver={onMouseOver}
+            onContextMenu={onContextMenu}
+          />
+        );
+
+        expect(wrapper.html()).toEqual(
+          shallow(<td className='test cell' colSpan={5} rowSpan={4}>
+            <span style={{display:'block'}}>
+              <span className="placeholder">test</span>
+            </span>
+            <input style={{display:'none'}}/>
+          </td>).html())
+
+        wrapper.simulate('mousedown');
+        wrapper.simulate('doubleclick');
+        wrapper.simulate('mouseover');
+        wrapper.simulate('contextmenu');
+
+        expect(onDoubleClick.calledWith(2, 3)).toEqual(true);
+        expect(onMouseDown.calledWith(2, 3)).toEqual(true);
+        expect(onMouseOver.calledWith(2, 3)).toEqual(true);
+        const args = onContextMenu.getCall(0).args;
+        expect(args[1]).toEqual(2);
+        expect(args[2]).toEqual(3);
+        wrapper.unmount();
+      })
+
       it('should properly all update functions and render reading mode to editing mode ', () => {
         const props = {
           editing: false,


### PR DESCRIPTION
Adds the ability to have placeholder text within the cell. The placeholder text is a span with the `class: placeholder` for external styling options. In addition, I added a test to cover the placeholder case.