### PR TITLE
add props.parsePaste, with accompanying test

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ overflow | 'wrap'\|'nowrap'\|'clip' | Grid default for how to render overflow te
 onChange | func | onChange handler: `function(cell, i, j, newValue) {}`
 onPaste | func | onPaste handler: `function(array) {}` If set, the function will be called with an array of rows. Each row has an array of objects containing the cell and raw pasted value. If the pasted value cannot be matched with a cell, the cell value will be undefined
 onContextMenu | func | Context menu handler : `function(event, cell, i, j)`
-parsePaste | func | `function (string) {}` If set, the function will be called with the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with `\r\n|\n|\r/` and cells with `\t`.
+parsePaste | func | `function (string) {}` If set, the function will be called with the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with line breaks and cells with tabs.
 
 ## Cell Options
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ overflow | 'wrap'\|'nowrap'\|'clip' | Grid default for how to render overflow te
 onChange | func | onChange handler: `function(cell, i, j, newValue) {}`
 onPaste | func | onPaste handler: `function(array) {}` If set, the function will be called with an array of rows. Each row has an array of objects containing the cell and raw pasted value. If the pasted value cannot be matched with a cell, the cell value will be undefined
 onContextMenu | func | Context menu handler : `function(event, cell, i, j)`
+parsePaste | func | `function (string) {}` If set, the function will be called with the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with `\r\n|\n|\r/` and cells with `\t`.
 
 ## Cell Options
 

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -149,7 +149,7 @@ var DataSheet = function (_PureComponent) {
         var start = this.state.start;
 
         var pastedMap = [];
-        var pasteData = e.clipboardData.getData('text/plain').split(/\n|\r/).map(function (row) {
+        var pasteData = e.clipboardData.getData('text/plain').split(/\r\n|\n|\r/).map(function (row) {
           return row.split('\t');
         });
         var end = {};

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -26,6 +26,11 @@ const range = (start, end) => {
 
 const nullFtn = (obj) => {};
 
+const defaultParsePaste = (str) => {
+  return str.split(/\r\n|\n|\r/)
+    .map((row) => row.split('\t'));
+}
+
 export default class DataSheet extends PureComponent {
 
   constructor(props) {
@@ -99,11 +104,10 @@ export default class DataSheet extends PureComponent {
     if(isEmpty(this.state.editing)) {
       const start = this.state.start;
 
+      const parse = this.props.parsePaste || defaultParsePaste;
       const pastedMap = [];
-      const pasteData = e.clipboardData
-        .getData('text/plain')
-        .split(/\r\n|\n|\r/)
-        .map((row) => row.split('\t'));
+      const pasteData = parse(e.clipboardData.getData('text/plain'));
+
       let end = {};
 
       pasteData.map((row, i) => {
@@ -352,4 +356,5 @@ DataSheet.propTypes = {
   onContextMenu: PropTypes.func,
   valueRenderer: PropTypes.func.isRequired,
   dataRenderer: PropTypes.func,
+  parsePaste: PropTypes.func,
 };

--- a/test/Datasheet.js
+++ b/test/Datasheet.js
@@ -949,6 +949,30 @@ describe('Component', () => {
           document.dispatchEvent(evt);
       });
 
+      it('pastes data properly, using parsePaste if defined', () => {
+        const datacust = [[{data: 12, readOnly: true}, {data: 24, readOnly: false}],[{data: 1012, readOnly: true}, {data: 1024, readOnly: false}]];
+        customWrapper = mount(
+          <DataSheet
+            data = {datacust}
+            valueRenderer = {(cell) => cell.data}
+            onChange = {(cell, i, j, value) => datacust[i][j].data = value}
+            // "--" is our arbitrary row delimiter, "," is our arbitrary field delimiter
+            parsePaste = {(pasted) => {
+              return pasted.split('--').map((line) => line.split(','))
+            }}
+          />
+        );
+        customWrapper.find('td').at(1).simulate('mouseDown');
+
+        let evt = document.createEvent("HTMLEvents");
+        evt.initEvent("paste", false, true);
+        evt.clipboardData = { getData: (type)=> '99,100--1001,1002'};
+        document.dispatchEvent(evt);
+
+        expect(datacust[1].map(d => d.data)).toEqual([1012, '1001'])
+
+      });
+
 
 
       it('stops editing on outside page click', () => {


### PR DESCRIPTION
this addresses #38 

something I noticed while making this change, when you use the `parsePaste` prop, the data copied to the clipboard in `handleCopy` can't just be pasted right back into the sheet. Perhaps before merging this, should I extend the PR to include some way to customize `handleCopy`, so if someone really needs this they can customize both ends and have copy/paste into the same sheet work as expected?

I am also happy to add documentation for this change before merging this PR