### PR TITLE
Add `onCellsChanged` handler

### DIFF
--- a/docs/src/examples/BasicSheet.js
+++ b/docs/src/examples/BasicSheet.js
@@ -27,15 +27,13 @@ export default class BasicSheet extends React.Component {
         data={this.state.grid}
         valueRenderer={(cell) => cell.value}
         onContextMenu={(e, cell, i, j) => cell.readOnly ? e.preventDefault() : null}
-        onChange={(modifiedCell, rowI, colJ, value) =>
-          this.setState({
-            grid: this.state.grid.map((row) =>
-              row.map((cell) =>
-                (cell === modifiedCell) ? ({value: value}) : cell
-              )
-            )
+        onCellsChanged={changes => {
+          const grid = this.state.grid.map(row => [...row])
+          changes.forEach(({cell, row, col, value}) => {
+            grid[row][col] = {...grid[row][col], value}
           })
-        }
+          this.setState({grid})
+        }}
       />
     )
   }

--- a/docs/src/examples/CustomRendererSheet.js
+++ b/docs/src/examples/CustomRendererSheet.js
@@ -178,7 +178,7 @@ class CustomRendererSheet extends PureComponent {
 
     this.handleColumnDrop = this.handleColumnDrop.bind(this)
     this.handleRowDrop = this.handleRowDrop.bind(this)
-    this.handleChange = this.handleChange.bind(this)
+    this.handleChanges = this.handleChanges.bind(this)
     this.renderSheet = this.renderSheet.bind(this)
     this.renderRow = this.renderRow.bind(this)
   }
@@ -200,13 +200,14 @@ class CustomRendererSheet extends PureComponent {
     this.setState({ grid })
   }
 
-  handleChange (modifiedCell, i, j, value) {
-    this.setState((prevState) => {
-      const grid = [...prevState.grid]
-      grid[i] = [...grid[i]]
-      grid[i][j] = {...grid[i][j], value}
-      return {grid}
+  handleChanges (changes) {
+    const grid = this.state.grid.map(row => [...row])
+    changes.forEach(({cell, row, col, value}) => {
+      if (grid[row] && grid[row][col]) {
+        grid[row][col] = {...grid[row][col], value}
+      }
     })
+    this.setState({grid})
   }
 
   renderSheet (props) {
@@ -226,7 +227,7 @@ class CustomRendererSheet extends PureComponent {
           valueRenderer={(cell) => cell.value}
           sheetRenderer={this.renderSheet}
           rowRenderer={this.renderRow}
-          onChange={this.handleChange}
+          onCellsChanged={this.handleChanges}
         />
       </DragDropContextProvider>
     )

--- a/docs/src/examples/MathSheet.js
+++ b/docs/src/examples/MathSheet.js
@@ -4,9 +4,9 @@ import mathjs from 'mathjs';
 import Datasheet from '../lib/DataSheet'
 
 export default class MathSheet extends React.Component {
-  constructor(props) {  
+  constructor(props) {
     super(props)
-    this.onChange = this.onChange.bind(this);
+    this.onCellsChanged = this.onCellsChanged.bind(this);
     this.state = {
       'A1': {key: 'A1', value: '200', expr: '200'},
       'A2': {key: 'A2', value: '200', expr: '=A1', className:'equation'},
@@ -90,11 +90,14 @@ export default class MathSheet extends React.Component {
     return state
   }
 
-  onChange(changeCell, i, j, expr) {
+  onCellsChanged(changes) {
     const state = _.assign({}, this.state)
-    this.cellUpdate(state, changeCell, expr)
+    changes.forEach(({cell, value}) => {
+      this.cellUpdate(state, cell, value)
+    })
     this.setState(state)
   }
+
   render() {
 
     return (
@@ -102,7 +105,7 @@ export default class MathSheet extends React.Component {
         data={this.generateGrid()}
         valueRenderer={(cell) => cell.value}
         dataRenderer={(cell) => cell.expr}
-        onChange={this.onChange}
+        onCellsChanged={this.onCellsChanged}
       />
     )
   }

--- a/docs/src/examples/OverrideEverythingSheet.js
+++ b/docs/src/examples/OverrideEverythingSheet.js
@@ -71,7 +71,7 @@ export default class OverrideEverythingSheet extends PureComponent {
     this.handleSelect = this.handleSelect.bind(this)
     this.handleSelectAllChanged = this.handleSelectAllChanged.bind(this)
     this.handleSelectChanged = this.handleSelectChanged.bind(this)
-    this.handleChange = this.handleChange.bind(this)
+    this.handleCellsChanged = this.handleCellsChanged.bind(this)
 
     this.sheetRenderer = this.sheetRenderer.bind(this)
     this.rowRenderer = this.rowRenderer.bind(this)
@@ -120,13 +120,21 @@ export default class OverrideEverythingSheet extends PureComponent {
     this.setState({selections})
   }
 
-  handleChange (modifiedCell, i, j, value) {
-    this.setState((prevState) => {
-      const grid = [...prevState.grid]
-      grid[i] = [...grid[i]]
-      grid[i][j] = {...grid[i][j], value}
-      return {grid}
+  handleCellsChanged (changes, additions) {
+    const grid = this.state.grid.map(row => [...row])
+    changes.forEach(({cell, row, col, value}) => {
+      grid[row][col] = {...grid[row][col], value}
     })
+    // paste extended beyond end, so add a new row
+    additions.forEach(({cell, row, col, value}) => {
+      if (!grid[row]) {
+        grid[row] = [{value: ''}, {value: ''}, {value: ''}, {value: 0}]
+      }
+      if (grid[row][col]) {
+        grid[row][col] = {...grid[row][col], value}
+      }
+    })
+    this.setState({grid})
   }
 
   sheetRenderer (props) {
@@ -186,7 +194,7 @@ export default class OverrideEverythingSheet extends PureComponent {
           bodyRenderer={this.bodyRenderer}
           rowRenderer={this.rowRenderer}
           cellRenderer={this.cellRenderer}
-          onChange={this.handleChange}
+          onCellsChanged={this.handleCellsChanged}
           valueRenderer={(cell) => cell.value}
         />
       </div>

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
@@ -168,30 +170,53 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'handlePaste',
     value: function handlePaste(e) {
-      var _this2 = this;
-
       if (isEmpty(this.state.editing)) {
         var start = this.state.start;
 
         var parse = this.props.parsePaste || defaultParsePaste;
-        var pastedMap = [];
+        var changes = [];
         var pasteData = parse(e.clipboardData.getData('text/plain'));
+        // in order of preference
+        var _props2 = this.props,
+            data = _props2.data,
+            onCellsChanged = _props2.onCellsChanged,
+            onPaste = _props2.onPaste,
+            onChange = _props2.onChange;
 
         var end = {};
-
-        pasteData.map(function (row, i) {
-          var rowData = [];
-          row.map(function (pastedData, j) {
-            var cell = _this2.props.data[start.i + i] && _this2.props.data[start.i + i][start.j + j];
-            rowData.push({ cell: cell, data: pastedData });
-            if (cell && !cell.readOnly && !_this2.props.onPaste) {
-              _this2.props.onChange(cell, start.i + i, start.j + j, pastedData);
+        if (onCellsChanged) {
+          pasteData.forEach(function (row, i) {
+            row.forEach(function (value, j) {
               end = { i: start.i + i, j: start.j + j };
-            }
+              var cell = data[end.i] && data[end.i][end.j];
+              if (!cell || !cell.readOnly) {
+                changes.push({ cell: cell, row: end.i, col: end.j, value: value });
+              }
+            });
           });
-          pastedMap.push(rowData);
-        });
-        this.props.onPaste && this.props.onPaste(pastedMap);
+          onCellsChanged(changes);
+        } else if (onPaste) {
+          pasteData.forEach(function (row, i) {
+            var rowData = [];
+            row.forEach(function (pastedData, j) {
+              end = { i: start.i + i, j: start.j + j };
+              var cell = data[end.i] && data[end.i][end.j];
+              rowData.push({ cell: cell, data: pastedData });
+            });
+            changes.push(rowData);
+          });
+          onPaste(changes);
+        } else if (onChange) {
+          pasteData.forEach(function (row, i) {
+            row.forEach(function (value, j) {
+              end = { i: start.i + i, j: start.j + j };
+              var cell = data[end.i] && data[end.i][end.j];
+              if (cell && !cell.readOnly) {
+                onChange(cell, end.i, end.j, value);
+              }
+            });
+          });
+        }
         this.setState({ end: end });
       }
     }
@@ -244,21 +269,8 @@ var DataSheet = function (_PureComponent) {
       }
     }
   }, {
-    key: 'getSelectedCells',
-    value: function getSelectedCells(data, start, end) {
-      var selected = [];
-      range(start.i, end.i).map(function (i) {
-        range(start.j, end.j).map(function (j) {
-          selected.push({ cell: data[i][j], i: i, j: j });
-        });
-      });
-      return selected;
-    }
-  }, {
     key: 'handleKey',
     value: function handleKey(e) {
-      var _this3 = this;
-
       if (e.isPropagationStopped && e.isPropagationStopped()) {
         return;
       }
@@ -268,7 +280,6 @@ var DataSheet = function (_PureComponent) {
           end = _state3.end,
           editing = _state3.editing;
 
-      var data = this.props.data;
       var isEditing = editing && !isEmpty(editing);
       var noCellsSelected = !start || isEmpty(start);
       var ctrlKeyPressed = e.ctrlKey || e.metaKey;
@@ -277,7 +288,7 @@ var DataSheet = function (_PureComponent) {
       var numbersPressed = keyCode >= 48 && keyCode <= 57;
       var lettersPressed = keyCode >= 65 && keyCode <= 90;
       var numPadKeysPressed = keyCode >= 96 && keyCode <= 105;
-      var currentCell = !noCellsSelected && data[start.i][start.j];
+      var currentCell = !noCellsSelected && this.props.data[start.i][start.j];
       var equationKeysPressed = [187, /* equal */
       189, /* substract */
       190, /* period */
@@ -292,17 +303,8 @@ var DataSheet = function (_PureComponent) {
       if (!isEditing) {
         this.handleKeyboardCellMovement(e);
         if (deleteKeysPressed) {
-          // ugly solution brought to you by https://reactjs.org/docs/react-component.html#setstate
-          // setState in a loop is unreliable
-          setTimeout(function () {
-            _this3.getSelectedCells(data, start, end).map(function (_ref) {
-              var cell = _ref.cell,
-                  i = _ref.i,
-                  j = _ref.j;
-              return !cell.readOnly ? _this3.onChange(i, j, '') : null;
-            });
-          }, 0);
           e.preventDefault();
+          this.clearSelectedCells(start, end);
         } else if (currentCell && !currentCell.readOnly) {
           if (enterKeyPressed) {
             this.setState({ editing: start, clear: {}, forceEdit: true });
@@ -315,9 +317,56 @@ var DataSheet = function (_PureComponent) {
       }
     }
   }, {
+    key: 'getSelectedCells',
+    value: function getSelectedCells(data, start, end) {
+      var selected = [];
+      range(start.i, end.i).map(function (row) {
+        range(start.j, end.j).map(function (col) {
+          if (data[row] && data[row][col]) {
+            selected.push({ cell: data[row][col], row: row, col: col });
+          }
+        });
+      });
+      return selected;
+    }
+  }, {
+    key: 'clearSelectedCells',
+    value: function clearSelectedCells(start, end) {
+      var _this2 = this;
+
+      var _props3 = this.props,
+          data = _props3.data,
+          onCellsChanged = _props3.onCellsChanged,
+          onChange = _props3.onChange;
+
+      var cells = this.getSelectedCells(data, start, end).filter(function (cell) {
+        return !cell.cell.readOnly;
+      }).map(function (cell) {
+        return _extends({}, cell, { value: '' });
+      });
+      if (onCellsChanged) {
+        onCellsChanged(cells);
+        this.onRevert();
+      } else if (onChange) {
+        // ugly solution brought to you by https://reactjs.org/docs/react-component.html#setstate
+        // setState in a loop is unreliable
+        setTimeout(function () {
+          cells.forEach(function (_ref) {
+            var cell = _ref.cell,
+                row = _ref.row,
+                col = _ref.col,
+                value = _ref.value;
+
+            onChange(cell, row, col, value);
+          });
+          _this2.onRevert();
+        }, 0);
+      }
+    }
+  }, {
     key: 'handleNavigate',
     value: function handleNavigate(e, offsets, jumpRow) {
-      var _this4 = this;
+      var _this3 = this;
 
       if (offsets && (offsets.i || offsets.j)) {
         var start = this.state.start;
@@ -326,7 +375,7 @@ var DataSheet = function (_PureComponent) {
         var newLocation = { i: start.i + offsets.i, j: start.j + offsets.j };
         var updateLocation = function updateLocation() {
           if (data[newLocation.i] && typeof data[newLocation.i][newLocation.j] !== 'undefined') {
-            _this4.setState({ start: newLocation, end: newLocation, editing: {} });
+            _this3.setState({ start: newLocation, end: newLocation, editing: {} });
             e.preventDefault();
             return true;
           }
@@ -345,7 +394,7 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'handleComponentKey',
     value: function handleComponentKey(e) {
-      var _this5 = this;
+      var _this4 = this;
 
       // handles keyboard events when editing components
       var keyCode = e.which || e.keyCode;
@@ -364,16 +413,16 @@ var DataSheet = function (_PureComponent) {
           var func = this.onRevert; // ESCAPE_KEY
           if (keyCode === _keys.ENTER_KEY) {
             func = function func() {
-              return _this5.handleNavigate(e, { i: offset, j: 0 });
+              return _this4.handleNavigate(e, { i: offset, j: 0 });
             };
           } else if (keyCode === _keys.TAB_KEY) {
             func = function func() {
-              return _this5.handleNavigate(e, { i: 0, j: offset }, true);
+              return _this4.handleNavigate(e, { i: 0, j: offset }, true);
             };
           }
           // setTimeout makes sure that component is done handling the event before we take over
           setTimeout(function () {
-            func();_this5.dgDom && _this5.dgDom.focus();
+            func();_this4.dgDom && _this4.dgDom.focus();
           }, 1);
         }
       }
@@ -424,8 +473,17 @@ var DataSheet = function (_PureComponent) {
     }
   }, {
     key: 'onChange',
-    value: function onChange(i, j, val) {
-      this.props.onChange(this.props.data[i][j], i, j, val);
+    value: function onChange(row, col, value) {
+      var _props4 = this.props,
+          onChange = _props4.onChange,
+          onCellsChanged = _props4.onCellsChanged,
+          data = _props4.data;
+
+      if (onCellsChanged) {
+        onCellsChanged([{ cell: data[row][col], row: row, col: col, value: value }]);
+      } else if (onChange) {
+        onChange(data[row][col], row, col, value);
+      }
       this.onRevert();
     }
   }, {
@@ -467,28 +525,28 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'render',
     value: function render() {
-      var _this6 = this;
+      var _this5 = this;
 
-      var _props2 = this.props,
-          SheetRenderer = _props2.sheetRenderer,
-          RowRenderer = _props2.rowRenderer,
-          cellRenderer = _props2.cellRenderer,
-          dataRenderer = _props2.dataRenderer,
-          valueRenderer = _props2.valueRenderer,
-          dataEditor = _props2.dataEditor,
-          valueViewer = _props2.valueViewer,
-          attributesRenderer = _props2.attributesRenderer,
-          className = _props2.className,
-          overflow = _props2.overflow,
-          data = _props2.data,
-          keyFn = _props2.keyFn;
+      var _props5 = this.props,
+          SheetRenderer = _props5.sheetRenderer,
+          RowRenderer = _props5.rowRenderer,
+          cellRenderer = _props5.cellRenderer,
+          dataRenderer = _props5.dataRenderer,
+          valueRenderer = _props5.valueRenderer,
+          dataEditor = _props5.dataEditor,
+          valueViewer = _props5.valueViewer,
+          attributesRenderer = _props5.attributesRenderer,
+          className = _props5.className,
+          overflow = _props5.overflow,
+          data = _props5.data,
+          keyFn = _props5.keyFn;
       var forceEdit = this.state.forceEdit;
 
 
       return _react2.default.createElement(
         'span',
         { ref: function ref(r) {
-            _this6.dgDom = r;
+            _this5.dgDom = r;
           }, tabIndex: '0', className: 'data-grid-container', onKeyDown: this.handleKey },
         _react2.default.createElement(
           SheetRenderer,
@@ -506,17 +564,17 @@ var DataSheet = function (_PureComponent) {
                   col: j,
                   cell: cell,
                   forceEdit: forceEdit,
-                  onMouseDown: _this6.onMouseDown,
-                  onMouseOver: _this6.onMouseOver,
-                  onDoubleClick: _this6.onDoubleClick,
-                  onContextMenu: _this6.onContextMenu,
-                  onChange: _this6.onChange,
-                  onRevert: _this6.onRevert,
-                  onNavigate: _this6.handleKeyboardCellMovement,
-                  onKey: _this6.handleKey,
-                  selected: _this6.isSelected(i, j),
-                  editing: _this6.isEditing(i, j),
-                  clearing: _this6.isClearing(i, j),
+                  onMouseDown: _this5.onMouseDown,
+                  onMouseOver: _this5.onMouseOver,
+                  onDoubleClick: _this5.onDoubleClick,
+                  onContextMenu: _this5.onContextMenu,
+                  onChange: _this5.onChange,
+                  onRevert: _this5.onRevert,
+                  onNavigate: _this5.handleKeyboardCellMovement,
+                  onKey: _this5.handleKey,
+                  selected: _this5.isSelected(i, j),
+                  editing: _this5.isEditing(i, j),
+                  clearing: _this5.isClearing(i, j),
                   attributesRenderer: attributesRenderer,
                   cellRenderer: cellRenderer,
                   valueRenderer: valueRenderer,
@@ -543,6 +601,7 @@ DataSheet.propTypes = {
   className: _propTypes2.default.string,
   overflow: _propTypes2.default.oneOf(['wrap', 'nowrap', 'clip']),
   onChange: _propTypes2.default.func,
+  onCellsChanged: _propTypes2.default.func,
   onContextMenu: _propTypes2.default.func,
   valueRenderer: _propTypes2.default.func.isRequired,
   dataRenderer: _propTypes2.default.func,


### PR DESCRIPTION
Adds `onCellsChanged` handler as discussed in #58. It still supports `onChanged` and `onPaste` if `onCellsChanged` is not provided.

Closes #58