### PR TITLE
It does not lose the selected cells on outside page click

### DIFF
--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -80,8 +80,9 @@ export default class DataSheet extends PureComponent {
 
   pageClick (e) {
     const element = this.dgDom
+    const { start, end } = this.state
     if (!element.contains(e.target)) {
-      this.setState(this.defaultState)
+      this.setState({ ...this.defaultState, ...{ start, end } })
       this.removeAllListeners()
     }
   }

--- a/test/Datasheet.js
+++ b/test/Datasheet.js
@@ -1100,8 +1100,8 @@ describe('Component', () => {
         triggerMouseEvent(document, 'mousedown')
 
         expect(wrapper.state()).toEqual({
-          start: {},
-          end: {},
+          start: wrapper.state().start,
+          end: wrapper.state().end,
           selecting: false,
           editing: {},
           forceEdit: false,


### PR DESCRIPTION
When click outside the component the default state was set to cancel possible edition of cells, but the component was losing the selection.