### PR TITLE
Controlled selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ rowRenderer | func | Optional function or React Component to render each row ele
 cellRenderer | func | Optional function or React Component to render each cell element. The default renders a `td` element.
 valueViewer | func | Optional function or React Component to customize the way the value for each cell in the sheet is displayed. Affects every cell in the sheet. See [cell options](https://github.com/nadbm/react-datasheet#cell-options) to override individual cells.
 dataEditor | func | Optional function or React Component to render a custom editor. Affects every cell in the sheet. Affects every cell in the sheet. See [cell options](https://github.com/nadbm/react-datasheet#cell-options) to override individual cells.
-selected | object | Optional. Wheter the selection is controlled or uncontrolled. Must be an object of this format: `{ start: { i: number, j; number }, end: { i: number, j: number } }`, or `null` for no selection.
+selected | object | Optional. Whether the selection is controlled or uncontrolled. Must be an object of this format: `{ start: { i: number, j; number }, end: { i: number, j: number } }`, or `null` for no selection.
 onSelect | func | Optional. `function ({ start, end }) {}` Triggered on every selection change. `start` and `end` have the same format as the `selected` prop. 
 
 ## `onCellsChanged(arrayOfChanges[, arrayOfAdditions])` handler

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ rowRenderer | func | Optional function or React Component to render each row ele
 cellRenderer | func | Optional function or React Component to render each cell element. The default renders a `td` element.
 valueViewer | func | Optional function or React Component to customize the way the value for each cell in the sheet is displayed. Affects every cell in the sheet. See [cell options](https://github.com/nadbm/react-datasheet#cell-options) to override individual cells.
 dataEditor | func | Optional function or React Component to render a custom editor. Affects every cell in the sheet. Affects every cell in the sheet. See [cell options](https://github.com/nadbm/react-datasheet#cell-options) to override individual cells.
+selected | object | Optional. Wheter the selection is controlled or uncontrolled. Must be an object of this format: `{ start: { i: number, j; number }, end: { i: number, j: number } }`, or `null` for no selection.
+onSelect | func | Optional. `function ({ start, end }) {}` Triggered on every selection change. `start` and `end` have the same format as the `selected` prop. 
 
 ## `onCellsChanged(arrayOfChanges[, arrayOfAdditions])` handler
 

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -185,16 +185,23 @@ var DataSheet = function (_PureComponent) {
 
         var end = {};
         if (onCellsChanged) {
+          var additions = [];
           pasteData.forEach(function (row, i) {
             row.forEach(function (value, j) {
               end = { i: start.i + i, j: start.j + j };
               var cell = data[end.i] && data[end.i][end.j];
-              if (!cell || !cell.readOnly) {
+              if (!cell) {
+                additions.push({ row: end.i, col: end.j, value: value });
+              } else if (!cell.readOnly) {
                 changes.push({ cell: cell, row: end.i, col: end.j, value: value });
               }
             });
           });
-          onCellsChanged(changes);
+          if (additions.length) {
+            onCellsChanged(changes, additions);
+          } else {
+            onCellsChanged(changes);
+          }
         } else if (onPaste) {
           pasteData.forEach(function (row, i) {
             var rowData = [];
@@ -495,9 +502,13 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps, prevState) {
+      var _state4 = this.state,
+          start = _state4.start,
+          end = _state4.end;
+
       var prevEnd = prevState.end;
-      if (!isEmpty(this.state.end) && !(this.state.end.i === prevEnd.i && this.state.end.j === prevEnd.j)) {
-        this.props.onSelect && this.props.onSelect(this.props.data[this.state.end.i][this.state.end.j]);
+      if (!isEmpty(end) && !(end.i === prevEnd.i && end.j === prevEnd.j)) {
+        this.props.onSelect && this.props.onSelect({ start: start, end: end });
       }
     }
   }, {

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -670,7 +670,16 @@ DataSheet.propTypes = {
   onCellsChanged: _propTypes2.default.func,
   onContextMenu: _propTypes2.default.func,
   onSelect: _propTypes2.default.func,
-  selected: _propTypes2.default.object,
+  selected: _propTypes2.default.shape({
+    start: _propTypes2.default.shape({
+      i: _propTypes2.default.number,
+      j: _propTypes2.default.number
+    }),
+    end: _propTypes2.default.shape({
+      i: _propTypes2.default.number,
+      j: _propTypes2.default.number
+    })
+  }),
   valueRenderer: _propTypes2.default.func.isRequired,
   dataRenderer: _propTypes2.default.func,
   sheetRenderer: _propTypes2.default.func.isRequired,

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -44,6 +44,8 @@ var _keys = require('./keys');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -132,6 +134,51 @@ var DataSheet = function (_PureComponent) {
       this.removeAllListeners();
     }
   }, {
+    key: 'isSelectionControlled',
+    value: function isSelectionControlled() {
+      return 'selected' in this.props;
+    }
+  }, {
+    key: 'getState',
+    value: function getState() {
+      var state = this.state;
+      if (this.isSelectionControlled()) {
+        var _ref = this.props.selected || {},
+            start = _ref.start,
+            end = _ref.end;
+
+        start = start || this.defaultState.start;
+        end = end || this.defaultState.end;
+        state = _extends({}, state, { start: start, end: end });
+      }
+      return state;
+    }
+  }, {
+    key: '_setState',
+    value: function _setState(state) {
+      if (this.isSelectionControlled() && ('start' in state || 'end' in state)) {
+        var start = state.start,
+            end = state.end,
+            rest = _objectWithoutProperties(state, ['start', 'end']);
+
+        var _props = this.props,
+            selected = _props.selected,
+            onSelect = _props.onSelect;
+
+        selected = selected || {};
+        if (!start) {
+          start = 'start' in selected ? selected.start : this.defaultState.start;
+        }
+        if (!end) {
+          end = 'end' in selected ? selected.end : this.defaultState.end;
+        }
+        onSelect && onSelect({ start: start, end: end });
+        this.setState(rest);
+      } else {
+        this.setState(state);
+      }
+    }
+  }, {
     key: 'pageClick',
     value: function pageClick(e) {
       var element = this.dgDom;
@@ -145,14 +192,14 @@ var DataSheet = function (_PureComponent) {
     value: function handleCopy(e) {
       if (isEmpty(this.state.editing)) {
         e.preventDefault();
-        var _props = this.props,
-            dataRenderer = _props.dataRenderer,
-            valueRenderer = _props.valueRenderer,
-            data = _props.data;
-        var _state = this.state,
-            start = _state.start,
-            end = _state.end;
+        var _props2 = this.props,
+            dataRenderer = _props2.dataRenderer,
+            valueRenderer = _props2.valueRenderer,
+            data = _props2.data;
 
+        var _getState = this.getState(),
+            start = _getState.start,
+            end = _getState.end;
 
         var text = range(start.i, end.i).map(function (i) {
           return range(start.j, end.j).map(function (j) {
@@ -171,17 +218,18 @@ var DataSheet = function (_PureComponent) {
     key: 'handlePaste',
     value: function handlePaste(e) {
       if (isEmpty(this.state.editing)) {
-        var start = this.state.start;
+        var _getState2 = this.getState(),
+            start = _getState2.start;
 
         var parse = this.props.parsePaste || defaultParsePaste;
         var changes = [];
         var pasteData = parse(e.clipboardData.getData('text/plain'));
         // in order of preference
-        var _props2 = this.props,
-            data = _props2.data,
-            onCellsChanged = _props2.onCellsChanged,
-            onPaste = _props2.onPaste,
-            onChange = _props2.onChange;
+        var _props3 = this.props,
+            data = _props3.data,
+            onCellsChanged = _props3.onCellsChanged,
+            onPaste = _props3.onPaste,
+            onChange = _props3.onChange;
 
         var end = {};
         if (onCellsChanged) {
@@ -224,16 +272,18 @@ var DataSheet = function (_PureComponent) {
             });
           });
         }
-        this.setState({ end: end });
+        this._setState({ end: end });
       }
     }
   }, {
     key: 'handleKeyboardCellMovement',
     value: function handleKeyboardCellMovement(e) {
       var commit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
-      var _state2 = this.state,
-          start = _state2.start,
-          editing = _state2.editing;
+
+      var _getState3 = this.getState(),
+          start = _getState3.start,
+          editing = _getState3.editing;
+
       var data = this.props.data;
 
       var isEditing = editing && !isEmpty(editing);
@@ -282,10 +332,11 @@ var DataSheet = function (_PureComponent) {
         return;
       }
       var keyCode = e.which || e.keyCode;
-      var _state3 = this.state,
-          start = _state3.start,
-          end = _state3.end,
-          editing = _state3.editing;
+
+      var _getState4 = this.getState(),
+          start = _getState4.start,
+          end = _getState4.end,
+          editing = _getState4.editing;
 
       var isEditing = editing && !isEmpty(editing);
       var noCellsSelected = !start || isEmpty(start);
@@ -314,11 +365,11 @@ var DataSheet = function (_PureComponent) {
           this.clearSelectedCells(start, end);
         } else if (currentCell && !currentCell.readOnly) {
           if (enterKeyPressed) {
-            this.setState({ editing: start, clear: {}, forceEdit: true });
+            this._setState({ editing: start, clear: {}, forceEdit: true });
             e.preventDefault();
           } else if (numbersPressed || numPadKeysPressed || lettersPressed || equationKeysPressed) {
             // empty out cell if user starts typing without pressing enter
-            this.setState({ editing: start, clear: start, forceEdit: false });
+            this._setState({ editing: start, clear: start, forceEdit: false });
           }
         }
       }
@@ -341,10 +392,10 @@ var DataSheet = function (_PureComponent) {
     value: function clearSelectedCells(start, end) {
       var _this2 = this;
 
-      var _props3 = this.props,
-          data = _props3.data,
-          onCellsChanged = _props3.onCellsChanged,
-          onChange = _props3.onChange;
+      var _props4 = this.props,
+          data = _props4.data,
+          onCellsChanged = _props4.onCellsChanged,
+          onChange = _props4.onChange;
 
       var cells = this.getSelectedCells(data, start, end).filter(function (cell) {
         return !cell.cell.readOnly;
@@ -358,11 +409,11 @@ var DataSheet = function (_PureComponent) {
         // ugly solution brought to you by https://reactjs.org/docs/react-component.html#setstate
         // setState in a loop is unreliable
         setTimeout(function () {
-          cells.forEach(function (_ref) {
-            var cell = _ref.cell,
-                row = _ref.row,
-                col = _ref.col,
-                value = _ref.value;
+          cells.forEach(function (_ref2) {
+            var cell = _ref2.cell,
+                row = _ref2.row,
+                col = _ref2.col,
+                value = _ref2.value;
 
             onChange(cell, row, col, value);
           });
@@ -376,13 +427,15 @@ var DataSheet = function (_PureComponent) {
       var _this3 = this;
 
       if (offsets && (offsets.i || offsets.j)) {
-        var start = this.state.start;
+        var _getState5 = this.getState(),
+            start = _getState5.start;
+
         var data = this.props.data;
 
         var newLocation = { i: start.i + offsets.i, j: start.j + offsets.j };
         var updateLocation = function updateLocation() {
           if (data[newLocation.i] && typeof data[newLocation.i][newLocation.j] !== 'undefined') {
-            _this3.setState({ start: newLocation, end: newLocation, editing: {} });
+            _this3._setState({ start: newLocation, end: newLocation, editing: {} });
             e.preventDefault();
             return true;
           }
@@ -447,14 +500,14 @@ var DataSheet = function (_PureComponent) {
     value: function onDoubleClick(i, j) {
       var cell = this.props.data[i][j];
       if (!cell.readOnly) {
-        this.setState({ editing: { i: i, j: j }, forceEdit: true, clear: {} });
+        this._setState({ editing: { i: i, j: j }, forceEdit: true, clear: {} });
       }
     }
   }, {
     key: 'onMouseDown',
     value: function onMouseDown(i, j) {
       var editing = isEmpty(this.state.editing) || this.state.editing.i !== i || this.state.editing.j !== j ? {} : this.state.editing;
-      this.setState({ selecting: true, start: { i: i, j: j }, end: { i: i, j: j }, editing: editing, forceEdit: false });
+      this._setState({ selecting: true, start: { i: i, j: j }, end: { i: i, j: j }, editing: editing, forceEdit: false });
 
       // Keep listening to mouse if user releases the mouse (dragging outside)
       document.addEventListener('mouseup', this.onMouseUp);
@@ -469,22 +522,22 @@ var DataSheet = function (_PureComponent) {
     key: 'onMouseOver',
     value: function onMouseOver(i, j) {
       if (this.state.selecting && isEmpty(this.state.editing)) {
-        this.setState({ end: { i: i, j: j } });
+        this._setState({ end: { i: i, j: j } });
       }
     }
   }, {
     key: 'onMouseUp',
     value: function onMouseUp() {
-      this.setState({ selecting: false });
+      this._setState({ selecting: false });
       document.removeEventListener('mouseup', this.onMouseUp);
     }
   }, {
     key: 'onChange',
     value: function onChange(row, col, value) {
-      var _props4 = this.props,
-          onChange = _props4.onChange,
-          onCellsChanged = _props4.onCellsChanged,
-          data = _props4.data;
+      var _props5 = this.props,
+          onChange = _props5.onChange,
+          onCellsChanged = _props5.onCellsChanged,
+          data = _props5.data;
 
       if (onCellsChanged) {
         onCellsChanged([{ cell: data[row][col], row: row, col: col, value: value }]);
@@ -496,26 +549,28 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'onRevert',
     value: function onRevert() {
-      this.setState({ editing: {} });
+      this._setState({ editing: {} });
       this.dgDom && this.dgDom.focus();
     }
   }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps, prevState) {
-      var _state4 = this.state,
-          start = _state4.start,
-          end = _state4.end;
+      var _state = this.state,
+          start = _state.start,
+          end = _state.end;
 
       var prevEnd = prevState.end;
-      if (!isEmpty(end) && !(end.i === prevEnd.i && end.j === prevEnd.j)) {
+      if (!isEmpty(end) && !(end.i === prevEnd.i && end.j === prevEnd.j) && !this.isSelectionControlled()) {
         this.props.onSelect && this.props.onSelect({ start: start, end: end });
       }
     }
   }, {
     key: 'isSelected',
     value: function isSelected(i, j) {
-      var start = this.state.start;
-      var end = this.state.end;
+      var _getState6 = this.getState(),
+          start = _getState6.start,
+          end = _getState6.end;
+
       var posX = j >= start.j && j <= end.j;
       var negX = j <= start.j && j >= end.j;
       var posY = i >= start.i && i <= end.i;
@@ -538,19 +593,19 @@ var DataSheet = function (_PureComponent) {
     value: function render() {
       var _this5 = this;
 
-      var _props5 = this.props,
-          SheetRenderer = _props5.sheetRenderer,
-          RowRenderer = _props5.rowRenderer,
-          cellRenderer = _props5.cellRenderer,
-          dataRenderer = _props5.dataRenderer,
-          valueRenderer = _props5.valueRenderer,
-          dataEditor = _props5.dataEditor,
-          valueViewer = _props5.valueViewer,
-          attributesRenderer = _props5.attributesRenderer,
-          className = _props5.className,
-          overflow = _props5.overflow,
-          data = _props5.data,
-          keyFn = _props5.keyFn;
+      var _props6 = this.props,
+          SheetRenderer = _props6.sheetRenderer,
+          RowRenderer = _props6.rowRenderer,
+          cellRenderer = _props6.cellRenderer,
+          dataRenderer = _props6.dataRenderer,
+          valueRenderer = _props6.valueRenderer,
+          dataEditor = _props6.dataEditor,
+          valueViewer = _props6.valueViewer,
+          attributesRenderer = _props6.attributesRenderer,
+          className = _props6.className,
+          overflow = _props6.overflow,
+          data = _props6.data,
+          keyFn = _props6.keyFn;
       var forceEdit = this.state.forceEdit;
 
 
@@ -614,6 +669,8 @@ DataSheet.propTypes = {
   onChange: _propTypes2.default.func,
   onCellsChanged: _propTypes2.default.func,
   onContextMenu: _propTypes2.default.func,
+  onSelect: _propTypes2.default.func,
+  selected: _propTypes2.default.object,
   valueRenderer: _propTypes2.default.func.isRequired,
   dataRenderer: _propTypes2.default.func,
   sheetRenderer: _propTypes2.default.func.isRequired,

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -78,6 +78,39 @@ export default class DataSheet extends PureComponent {
     this.removeAllListeners()
   }
 
+  isSelectionControlled () {
+    return ('selected' in this.props)
+  }
+
+  getState () {
+    let state = this.state
+    if (this.isSelectionControlled()) {
+      let { start, end } = this.props.selected || {}
+      start = start || this.defaultState.start
+      end = end || this.defaultState.end
+      state = { ...state, start, end }
+    }
+    return state
+  }
+
+  _setState (state) {
+    if (this.isSelectionControlled() && (('start' in state) || ('end' in state))) {
+      let { start, end, ...rest } = state
+      let { selected, onSelect } = this.props
+      selected = selected || {}
+      if (!start) {
+        start = 'start' in selected ? selected.start : this.defaultState.start
+      }
+      if (!end) {
+        end = 'end' in selected ? selected.end : this.defaultState.end
+      }
+      onSelect && onSelect({ start, end })
+      this.setState(rest)
+    } else {
+      this.setState(state)
+    }
+  }
+
   pageClick (e) {
     const element = this.dgDom
     if (!element.contains(e.target)) {
@@ -90,7 +123,7 @@ export default class DataSheet extends PureComponent {
     if (isEmpty(this.state.editing)) {
       e.preventDefault()
       const {dataRenderer, valueRenderer, data} = this.props
-      const {start, end} = this.state
+      const {start, end} = this.getState()
 
       const text = range(start.i, end.i).map((i) =>
         range(start.j, end.j).map(j => {
@@ -108,8 +141,7 @@ export default class DataSheet extends PureComponent {
 
   handlePaste (e) {
     if (isEmpty(this.state.editing)) {
-      const start = this.state.start
-
+      const { start } = this.getState()
       const parse = this.props.parsePaste || defaultParsePaste
       const changes = []
       const pasteData = parse(e.clipboardData.getData('text/plain'))
@@ -156,12 +188,12 @@ export default class DataSheet extends PureComponent {
           })
         })
       }
-      this.setState({end})
+      this._setState({end})
     }
   }
 
   handleKeyboardCellMovement (e, commit = false) {
-    const {start, editing} = this.state
+    const {start, editing} = this.getState()
     const {data} = this.props
     const isEditing = editing && !isEmpty(editing)
     const currentCell = data[start.i] && data[start.i][start.j]
@@ -207,7 +239,7 @@ export default class DataSheet extends PureComponent {
       return
     }
     const keyCode = e.which || e.keyCode
-    const {start, end, editing} = this.state
+    const {start, end, editing} = this.getState()
     const isEditing = editing && !isEmpty(editing)
     const noCellsSelected = !start || isEmpty(start)
     const ctrlKeyPressed = e.ctrlKey || e.metaKey
@@ -237,14 +269,14 @@ export default class DataSheet extends PureComponent {
         this.clearSelectedCells(start, end)
       } else if (currentCell && !currentCell.readOnly) {
         if (enterKeyPressed) {
-          this.setState({editing: start, clear: {}, forceEdit: true})
+          this._setState({editing: start, clear: {}, forceEdit: true})
           e.preventDefault()
         } else if (numbersPressed ||
             numPadKeysPressed ||
             lettersPressed ||
             equationKeysPressed) {
           // empty out cell if user starts typing without pressing enter
-          this.setState({editing: start, clear: start, forceEdit: false})
+          this._setState({editing: start, clear: start, forceEdit: false})
         }
       }
     }
@@ -284,12 +316,12 @@ export default class DataSheet extends PureComponent {
 
   handleNavigate (e, offsets, jumpRow) {
     if (offsets && (offsets.i || offsets.j)) {
-      const {start} = this.state
+      const {start} = this.getState()
       const {data} = this.props
       let newLocation = {i: start.i + offsets.i, j: start.j + offsets.j}
       const updateLocation = () => {
         if (data[newLocation.i] && typeof (data[newLocation.i][newLocation.j]) !== 'undefined') {
-          this.setState({start: newLocation, end: newLocation, editing: {}})
+          this._setState({start: newLocation, end: newLocation, editing: {}})
           e.preventDefault()
           return true
         }
@@ -342,14 +374,14 @@ export default class DataSheet extends PureComponent {
   onDoubleClick (i, j) {
     let cell = this.props.data[i][j]
     if (!cell.readOnly) {
-      this.setState({editing: {i: i, j: j}, forceEdit: true, clear: {}})
+      this._setState({editing: {i: i, j: j}, forceEdit: true, clear: {}})
     }
   }
 
   onMouseDown (i, j) {
     let editing = (isEmpty(this.state.editing) || this.state.editing.i !== i || this.state.editing.j !== j)
       ? {} : this.state.editing
-    this.setState({selecting: true, start: {i, j}, end: {i, j}, editing: editing, forceEdit: false})
+    this._setState({selecting: true, start: {i, j}, end: {i, j}, editing: editing, forceEdit: false})
 
     // Keep listening to mouse if user releases the mouse (dragging outside)
     document.addEventListener('mouseup', this.onMouseUp)
@@ -363,12 +395,12 @@ export default class DataSheet extends PureComponent {
 
   onMouseOver (i, j) {
     if (this.state.selecting && isEmpty(this.state.editing)) {
-      this.setState({end: {i, j}})
+      this._setState({end: {i, j}})
     }
   }
 
   onMouseUp () {
-    this.setState({selecting: false})
+    this._setState({selecting: false})
     document.removeEventListener('mouseup', this.onMouseUp)
   }
 
@@ -383,21 +415,20 @@ export default class DataSheet extends PureComponent {
   }
 
   onRevert () {
-    this.setState({ editing: {} })
+    this._setState({ editing: {} })
     this.dgDom && this.dgDom.focus()
   }
 
   componentDidUpdate (prevProps, prevState) {
     let { start, end } = this.state
     let prevEnd = prevState.end
-    if (!isEmpty(end) && !(end.i === prevEnd.i && end.j === prevEnd.j)) {
+    if (!isEmpty(end) && !(end.i === prevEnd.i && end.j === prevEnd.j) && !this.isSelectionControlled()) {
       this.props.onSelect && this.props.onSelect({ start, end })
     }
   }
 
   isSelected (i, j) {
-    const start = this.state.start
-    const end = this.state.end
+    const {start, end} = this.getState()
     const posX = (j >= start.j && j <= end.j)
     const negX = (j <= start.j && j >= end.j)
     const posY = (i >= start.i && i <= end.i)
@@ -473,6 +504,8 @@ DataSheet.propTypes = {
   onChange: PropTypes.func,
   onCellsChanged: PropTypes.func,
   onContextMenu: PropTypes.func,
+  onSelect: PropTypes.func,
+  selected: PropTypes.object,
   valueRenderer: PropTypes.func.isRequired,
   dataRenderer: PropTypes.func,
   sheetRenderer: PropTypes.func.isRequired,

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -388,9 +388,10 @@ export default class DataSheet extends PureComponent {
   }
 
   componentDidUpdate (prevProps, prevState) {
+    let { start, end } = this.state
     let prevEnd = prevState.end
-    if (!isEmpty(this.state.end) && !(this.state.end.i === prevEnd.i && this.state.end.j === prevEnd.j)) {
-      this.props.onSelect && this.props.onSelect(this.props.data[this.state.end.i][this.state.end.j])
+    if (!isEmpty(end) && !(end.i === prevEnd.i && end.j === prevEnd.j)) {
+      this.props.onSelect && this.props.onSelect({ start, end })
     }
   }
 

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -505,7 +505,16 @@ DataSheet.propTypes = {
   onCellsChanged: PropTypes.func,
   onContextMenu: PropTypes.func,
   onSelect: PropTypes.func,
-  selected: PropTypes.object,
+  selected: PropTypes.shape({
+    start: PropTypes.shape({
+      i: PropTypes.number,
+      j: PropTypes.number
+    }),
+    end: PropTypes.shape({
+      i: PropTypes.number,
+      j: PropTypes.number
+    })
+  }),
   valueRenderer: PropTypes.func.isRequired,
   dataRenderer: PropTypes.func,
   sheetRenderer: PropTypes.func.isRequired,

--- a/test/Datasheet.js
+++ b/test/Datasheet.js
@@ -656,9 +656,10 @@ describe('Component', () => {
         customWrapper = mount(
           <DataSheet
             data={data}
-            onSelect={(cell) => {
+            onSelect={({ start, end }) => {
               try {
-                expect(cell).toEqual({data: 4, className: 'test1', overflow: 'clip'})
+                expect(start).toEqual({ i: 0, j: 0 })
+                expect(end).toEqual({ i: 0, j: 0 })
                 done()
               } catch (err) {
                 done(err)

--- a/test/Datasheet.js
+++ b/test/Datasheet.js
@@ -369,6 +369,7 @@ describe('Component', () => {
     let component = null
     let wrapper = null
     let customWrapper = null
+    let selected = null
     jsdom()
 
     beforeEach(() => {
@@ -670,6 +671,28 @@ describe('Component', () => {
             />)
         customWrapper.find('td').at(0).simulate('mouseDown')
         expect(customWrapper.state('end')).toEqual({i: 0, j: 0})
+      })
+
+      it('calls onSelect prop when a new element is selected and the selection is controlled', (done) => {
+        customWrapper = mount(
+          <DataSheet
+            data={data}
+            selected={selected}
+            onSelect={({ start, end }) => {
+              try {
+                selected = { start, end }
+                expect(start).toEqual({ i: 0, j: 0 })
+                expect(end).toEqual({ i: 0, j: 0 })
+                done()
+              } catch (err) {
+                done(err)
+              }
+            }}
+            valueRenderer={(cell) => cell.data}
+            onChange={(cell, i, j, value) => custData[i][j].data = value}
+            />)
+        customWrapper.find('td').at(0).simulate('mouseDown')
+        expect(selected.end).toEqual({i: 0, j: 0})
       })
     })
 


### PR DESCRIPTION
I implemented an optional controlled selection, based on the discussion in #60. 

Instead of `if/else` all the code, I made a `getState()` and `_setState()` which returns/sets the selection from/to the state or props depending on whether the `selected` prop is defined. If `selected` is not passed, the component behaves as usual. 

Also, I skipped returning the cell in the `onSelect()` callback, since it's not necessary and could be confusing if there is more than one cell selected. Instead I just pass `{ start, end }`. A single cell can be easily accessed by: 
```
onSelect({ start, end}) {
  const cell = data[start.i][start.j]
  ...
}
```

Let me know what you guys think about this implementation. 
