### PR TITLE
Modify npm test script to allow for longer timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:watch": "watch 'npm run build' ./src",
     "prepublish": "npm run build",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "test": "standard src/*.js && NODE_ENV=test nyc --  mocha ./test/**/*.js --compilers js:babel-register",
+    "test": "standard src/*.js && NODE_ENV=test nyc --  mocha ./test/**/*.js --compilers js:babel-register --timeout 10000",
     "test:watch": "watch 'npm run test' ./test ./src"
   },
   "devDependencies": {


### PR DESCRIPTION
This change fixes the timeout error that was occuring upon testing which was causing tests to fail.  For further reference to the chosen solution, see [here](https://github.com/mochajs/mocha/issues/2025)