### PR TITLE
Support to start editing a cell when pressing characters from the unicode block "Latin-1 Supplement"

### DIFF
--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -345,6 +345,7 @@ var DataSheet = function (_PureComponent) {
       var enterKeyPressed = keyCode === _keys.ENTER_KEY;
       var numbersPressed = keyCode >= 48 && keyCode <= 57;
       var lettersPressed = keyCode >= 65 && keyCode <= 90;
+      var latin1Supplement = keyCode >= 160 && keyCode <= 255;
       var numPadKeysPressed = keyCode >= 96 && keyCode <= 105;
       var currentCell = !noCellsSelected && this.props.data[start.i][start.j];
       var equationKeysPressed = [187, /* equal */
@@ -367,7 +368,7 @@ var DataSheet = function (_PureComponent) {
           if (enterKeyPressed) {
             this._setState({ editing: start, clear: {}, forceEdit: true });
             e.preventDefault();
-          } else if (numbersPressed || numPadKeysPressed || lettersPressed || equationKeysPressed) {
+          } else if (numbersPressed || numPadKeysPressed || lettersPressed || latin1Supplement || equationKeysPressed) {
             // empty out cell if user starts typing without pressing enter
             this._setState({ editing: start, clear: start, forceEdit: false });
           }
@@ -688,7 +689,8 @@ DataSheet.propTypes = {
   valueViewer: _propTypes2.default.func,
   dataEditor: _propTypes2.default.func,
   parsePaste: _propTypes2.default.func,
-  attributesRenderer: _propTypes2.default.func
+  attributesRenderer: _propTypes2.default.func,
+  keyFn: _propTypes2.default.func
 };
 
 DataSheet.defaultProps = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-datasheet",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -247,6 +247,7 @@ export default class DataSheet extends PureComponent {
     const enterKeyPressed = keyCode === ENTER_KEY
     const numbersPressed = (keyCode >= 48 && keyCode <= 57)
     const lettersPressed = (keyCode >= 65 && keyCode <= 90)
+    const latin1Supplement = (keyCode >= 160 && keyCode <= 255)
     const numPadKeysPressed = (keyCode >= 96 && keyCode <= 105)
     const currentCell = !noCellsSelected && this.props.data[start.i][start.j]
     const equationKeysPressed = [
@@ -274,6 +275,7 @@ export default class DataSheet extends PureComponent {
         } else if (numbersPressed ||
             numPadKeysPressed ||
             lettersPressed ||
+            latin1Supplement ||
             equationKeysPressed) {
           // empty out cell if user starts typing without pressing enter
           this._setState({editing: start, clear: start, forceEdit: false})


### PR DESCRIPTION
I needed the cells to enter in edition mode when pressing the Norwegian characters æøå, and I thought to include the whole Unicode block where they appear. What do you think about that? 