### PR TITLE
Remove focus event from main body

### DIFF
--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -366,7 +366,7 @@ export default class DataSheet extends PureComponent {
           func = () => this.handleNavigate(e, {i: 0, j: offset}, true)
         }
         // setTimeout makes sure that component is done handling the event before we take over
-        setTimeout(() => { func(); this.dgDom && this.dgDom.focus() }, 1)
+        setTimeout(() => { func(); }, 1)
       }
     }
   }
@@ -424,7 +424,6 @@ export default class DataSheet extends PureComponent {
 
   onRevert () {
     this._setState({ editing: {} })
-    this.dgDom && this.dgDom.focus()
   }
 
   componentDidUpdate (prevProps, prevState) {
@@ -463,7 +462,7 @@ export default class DataSheet extends PureComponent {
     const {forceEdit} = this.state
 
     return (
-      <span ref={r => { this.dgDom = r }} tabIndex='0' className='data-grid-container' onKeyDown={this.handleKey}>
+      <span ref={r => { this.dgDom = r }} className='data-grid-container' onKeyDown={this.handleKey}>
         <SheetRenderer data={data} className={['data-grid', className, overflow].filter(a => a).join(' ')}>
           {data.map((row, i) =>
             <RowRenderer key={keyFn ? keyFn(i) : i} row={i} cells={row}>


### PR DESCRIPTION
Currently this focus event shifts the entire window scroll position to sit at the top of the spreadsheets position. Removing this focus event has no other effect that I have seen. If there is a reason for this focus event, can there please be a solution that doesn't involve focusing the main span into view and constantly shifting the windows scroll.

Also, in the scroll shifting, any horizontal scrolling that the spreadsheet sits in, gets reset back to 0. This is a big and annoying issue that this PR resolves