### PR TITLE
Move edit value from DataCell to DataSheet

### DIFF
--- a/src/DataCell.js
+++ b/src/DataCell.js
@@ -248,7 +248,7 @@ DataCell.propTypes = {
   forceEdit: PropTypes.bool,
   selected: PropTypes.bool,
   editing: PropTypes.bool,
-  editValue: PropTypes.any.isRequired,
+  editValue: PropTypes.any,
   clearing: PropTypes.bool,
   cellRenderer: PropTypes.func,
   valueRenderer: PropTypes.func.isRequired,
@@ -263,7 +263,7 @@ DataCell.propTypes = {
   onContextMenu: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
   onRevert: PropTypes.func.isRequired,
-  onEdit: PropTypes.func.isRequired
+  onEdit: PropTypes.func
 }
 
 DataCell.defaultProps = {

--- a/src/DataCell.js
+++ b/src/DataCell.js
@@ -43,10 +43,11 @@ export default class DataCell extends PureComponent {
     this.handleContextMenu = this.handleContextMenu.bind(this)
     this.handleDoubleClick = this.handleDoubleClick.bind(this)
 
+    this.getEditValue = this.getEditValue.bind(this)
+
     this.state = {
       updated: false,
       reverting: false,
-      value: '',
       committing: false
     }
   }
@@ -58,7 +59,8 @@ export default class DataCell extends PureComponent {
     }
     if (this.props.editing === true && prevProps.editing === false) {
       const value = this.props.clearing ? '' : initialData(this.props)
-      this.setState({ value, reverting: false })
+      this.setState({ reverting: false })
+      this.props.onEdit(value)
     }
 
     if (
@@ -66,9 +68,9 @@ export default class DataCell extends PureComponent {
       this.props.editing === false &&
       !this.state.reverting &&
       !this.state.committing &&
-      this.state.value !== initialData(this.props)
+      this.props.editValue !== initialData(this.props)
     ) {
-      this.props.onChange(this.props.row, this.props.col, this.state.value)
+      this.props.onChange(this.props.row, this.props.col, this.props.editValue)
     }
   }
 
@@ -77,14 +79,15 @@ export default class DataCell extends PureComponent {
   }
 
   handleChange (value) {
-    this.setState({ value, committing: false })
+    this.setState({ committing: false })
+    this.props.onEdit(value)
   }
 
   handleCommit (value, e) {
     const { onChange, onNavigate } = this.props
     if (value !== initialData(this.props)) {
-      this.setState({ value, committing: true })
-      onChange(this.props.row, this.props.col, value)
+      this.setState({ committing: true })
+      onChange(this.props.row, this.props.col, this.props.editValue)
     } else {
       this.handleRevert()
     }
@@ -143,8 +146,12 @@ export default class DataCell extends PureComponent {
       (!eatKeys && [LEFT_KEY, RIGHT_KEY, UP_KEY, DOWN_KEY].includes(keyCode))
 
     if (commit) {
-      this.handleCommit(this.state.value, e)
+      this.handleCommit(this.getEditValue(), e)
     }
+  }
+
+  getEditValue () {
+    return this.props.editValue === undefined ? '' : this.props.editValue
   }
 
   renderComponent (editing, cell) {
@@ -162,7 +169,7 @@ export default class DataCell extends PureComponent {
           cell={cell}
           row={row}
           col={col}
-          value={this.state.value}
+          value={this.getEditValue()}
           onChange={this.handleChange}
           onCommit={this.handleCommit}
           onRevert={this.handleRevert}
@@ -241,6 +248,7 @@ DataCell.propTypes = {
   forceEdit: PropTypes.bool,
   selected: PropTypes.bool,
   editing: PropTypes.bool,
+  editValue: PropTypes.any.isRequired,
   clearing: PropTypes.bool,
   cellRenderer: PropTypes.func,
   valueRenderer: PropTypes.func.isRequired,
@@ -254,7 +262,8 @@ DataCell.propTypes = {
   onDoubleClick: PropTypes.func.isRequired,
   onContextMenu: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
-  onRevert: PropTypes.func.isRequired
+  onRevert: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired
 }
 
 DataCell.defaultProps = {

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -34,6 +34,7 @@ export default class DataSheet extends PureComponent {
     this.onDoubleClick = this.onDoubleClick.bind(this)
     this.onContextMenu = this.onContextMenu.bind(this)
     this.handleNavigate = this.handleNavigate.bind(this)
+    this.handleEdit = this.handleEdit.bind(this)
     this.handleKey = this.handleKey.bind(this).bind(this)
     this.handleCut = this.handleCut.bind(this)
     this.handleCopy = this.handleCopy.bind(this)
@@ -244,6 +245,10 @@ export default class DataSheet extends PureComponent {
     } else if (commit && keyCode === ENTER_KEY) {
       this.handleNavigate(e, {i: e.shiftKey ? -1 : 1, j: 0})
     }
+  }
+
+  handleEdit (value) {
+    this.setState({ editValue: value })
   }
 
   handleKey (e) {
@@ -503,6 +508,7 @@ export default class DataSheet extends PureComponent {
             <RowRenderer key={keyFn ? keyFn(i) : i} row={i} cells={row}>
               {
                 row.map((cell, j) => {
+                  const isEditing = this.isEditing(i, j)
                   return (
                     <DataCell
                       key={cell.key ? cell.key : `${i}-${j}`}
@@ -519,7 +525,7 @@ export default class DataSheet extends PureComponent {
                       onNavigate={this.handleKeyboardCellMovement}
                       onKey={this.handleKey}
                       selected={this.isSelected(i, j)}
-                      editing={this.isEditing(i, j)}
+                      editing={isEditing}
                       clearing={this.isClearing(i, j)}
                       attributesRenderer={attributesRenderer}
                       cellRenderer={cellRenderer}
@@ -527,6 +533,12 @@ export default class DataSheet extends PureComponent {
                       dataRenderer={dataRenderer}
                       valueViewer={valueViewer}
                       dataEditor={dataEditor}
+                      editValue={this.state.editValue}
+                      {... isEditing ? {
+                        onEdit: this.handleEdit
+                      }
+                      : {}
+                      }
                     />
                   )
                 })

--- a/test/Datasheet.js
+++ b/test/Datasheet.js
@@ -101,6 +101,7 @@ describe('Component', () => {
           onDoubleClick: () => {},
           onContextMenu: () => {},
           onChange: () => {},
+          onEdit: sinon.spy(),
           valueRenderer: cell => cell.value
         }
         const wrapper = shallow(
@@ -113,10 +114,12 @@ describe('Component', () => {
             <span className='value-viewer'>5</span>
           </td>).html())
 
-        wrapper.setProps({ editing: true, selected: true }, () => {
+        wrapper.setProps({ editing: true, selected: true, editValue: 10 }, () => {
+          expect(props.onEdit.called).toEqual(true)
+          expect(props.onEdit.calledWith(5)).toEqual(true)
           expect(wrapper.html()).toEqual(
             shallow(<td className='cell selected editing'>
-              <input className='data-editor' value='5' />
+              <input className='data-editor' value='10' />
             </td>).html())
         })
       })
@@ -181,6 +184,7 @@ describe('Component', () => {
           },
           onContextMenu: () => {
           },
+          onEdit: sinon.spy(),
           valueRenderer: cell => cell.value,
           dataRenderer: cell => cell.data
         }
@@ -189,7 +193,7 @@ describe('Component', () => {
       })
 
       it('should not call onChange if value is the same', () => {
-        wrapper.setProps({editing: true, selected: true})
+        wrapper.setProps({editing: true, selected: true, editValue: '5'})
         expect(wrapper.find('input').node.value).toEqual('5')
         wrapper.find('input').node.value = '5'
         wrapper.find('input').simulate('change')
@@ -198,10 +202,12 @@ describe('Component', () => {
       })
 
       it('should properly call onChange', () => {
-        wrapper.setProps({editing: true, selected: true})
+        wrapper.setProps({editing: true, selected: true, editValue: '5'})
         wrapper.find('input').node.value = '6'
         wrapper.find('input').simulate('change')
-        wrapper.setProps({editing: false, selected: true})
+        expect(props.onEdit.called).toEqual(true)
+        expect(props.onEdit.calledWith('6')).toEqual(true)
+        wrapper.setProps({editing: false, selected: true, editValue: '6'})
         expect(props.onChange.called).toEqual(true)
         expect(props.onChange.calledWith(props.row, props.col, '6')).toEqual(true)
       })
@@ -212,12 +218,14 @@ describe('Component', () => {
       })
       it('input value should be set to value if data is null', () => {
         wrapper.setProps({cell: {data: null, value: '2'}})
-        wrapper.setProps({editing: true, selected: true})
+        wrapper.setProps({editing: true, selected: true, editValue: '2'})
+        expect(props.onEdit.called).toEqual(true)
+        expect(props.onEdit.calledWith('2')).toEqual(true)
         expect(wrapper.find('input').node.value).toEqual('2')
 
         wrapper.find('input').node.value = '2'
         wrapper.find('input').simulate('change')
-        wrapper.setProps({editing: false, selected: true})
+        wrapper.setProps({editing: false, selected: true, editValue: '2'})
         expect(props.onChange.called).toEqual(false)
       })
     })
@@ -951,6 +959,7 @@ describe('Component', () => {
           end: { i: 0, j: 0 },
           selecting: true,
           editing: { i: 0, j: 0 },
+          editValue: 4,
           forceEdit: true,
           clear: {}
         })
@@ -972,6 +981,7 @@ describe('Component', () => {
           end: { i: 0, j: 0 },
           selecting: true,
           editing: { i: 0, j: 0 },
+          editValue: '',
           forceEdit: false,
           clear: { i: 0, j: 0 }
         })
@@ -986,6 +996,7 @@ describe('Component', () => {
           end: { i: 0, j: 1 }, // RIGHT_KEY movement
           selecting: true,
           editing: {},
+          editValue: '213',
           forceEdit: false,
           clear: { i: 0, j: 0 }
         })
@@ -1003,6 +1014,7 @@ describe('Component', () => {
           end: { i: 0, j: 0 },
           selecting: true,
           editing: { i: 0, j: 0 },
+          editValue: '',
           forceEdit: false,
           clear: { i: 0, j: 0 }
         })
@@ -1012,6 +1024,7 @@ describe('Component', () => {
           end: { i: 0, j: 0 }, // RIGHT_KEY movement
           selecting: true,
           editing: { i: 0, j: 0 },
+          editValue: '',
           forceEdit: false,
           clear: { i: 0, j: 0 }
         })
@@ -1253,6 +1266,7 @@ describe('Component', () => {
           end: {},
           selecting: false,
           editing: {},
+          editValue: 4,
           forceEdit: false,
           clear: {}
         })


### PR DESCRIPTION
When a DataCell is in edit mode and the underlying data changes, the
edited value was lost since the value was local to DataCell, which was
recreated. This commit fixes the problem by moving the edit value to the
parent DataSheet component.