### PR TITLE
Fix memory leak and support copy/cut/patse on IE11

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">    
     <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/lib/DataCell.js
+++ b/lib/DataCell.js
@@ -84,10 +84,11 @@ var DataCell = function (_PureComponent) {
     _this.handleContextMenu = _this.handleContextMenu.bind(_this);
     _this.handleDoubleClick = _this.handleDoubleClick.bind(_this);
 
+    _this.getEditValue = _this.getEditValue.bind(_this);
+
     _this.state = {
       updated: false,
       reverting: false,
-      value: '',
       committing: false
     };
     return _this;
@@ -106,11 +107,12 @@ var DataCell = function (_PureComponent) {
       }
       if (this.props.editing === true && prevProps.editing === false) {
         var value = this.props.clearing ? '' : initialData(this.props);
-        this.setState({ value: value, reverting: false });
+        this.setState({ reverting: false });
+        this.props.onEdit(value);
       }
 
-      if (prevProps.editing === true && this.props.editing === false && !this.state.reverting && !this.state.committing && this.state.value !== initialData(this.props)) {
-        this.props.onChange(this.props.row, this.props.col, this.state.value);
+      if (prevProps.editing === true && this.props.editing === false && !this.state.reverting && !this.state.committing && this.props.editValue !== initialData(this.props)) {
+        this.props.onChange(this.props.row, this.props.col, this.props.editValue);
       }
     }
   }, {
@@ -121,7 +123,8 @@ var DataCell = function (_PureComponent) {
   }, {
     key: 'handleChange',
     value: function handleChange(value) {
-      this.setState({ value: value, committing: false });
+      this.setState({ committing: false });
+      this.props.onEdit(value);
     }
   }, {
     key: 'handleCommit',
@@ -131,8 +134,8 @@ var DataCell = function (_PureComponent) {
           onNavigate = _props.onNavigate;
 
       if (value !== initialData(this.props)) {
-        this.setState({ value: value, committing: true });
-        onChange(this.props.row, this.props.col, value);
+        this.setState({ committing: true });
+        onChange(this.props.row, this.props.col, this.props.editValue);
       } else {
         this.handleRevert();
       }
@@ -214,8 +217,13 @@ var DataCell = function (_PureComponent) {
       var commit = keyCode === _keys.ENTER_KEY || keyCode === _keys.TAB_KEY || !eatKeys && [_keys.LEFT_KEY, _keys.RIGHT_KEY, _keys.UP_KEY, _keys.DOWN_KEY].includes(keyCode);
 
       if (commit) {
-        this.handleCommit(this.state.value, e);
+        this.handleCommit(this.getEditValue(), e);
       }
+    }
+  }, {
+    key: 'getEditValue',
+    value: function getEditValue() {
+      return this.props.editValue === undefined ? '' : this.props.editValue;
     }
   }, {
     key: 'renderComponent',
@@ -237,7 +245,7 @@ var DataCell = function (_PureComponent) {
           cell: cell,
           row: row,
           col: col,
-          value: this.state.value,
+          value: this.getEditValue(),
           onChange: this.handleChange,
           onCommit: this.handleCommit,
           onRevert: this.handleRevert,
@@ -312,6 +320,7 @@ DataCell.propTypes = {
   forceEdit: _propTypes2.default.bool,
   selected: _propTypes2.default.bool,
   editing: _propTypes2.default.bool,
+  editValue: _propTypes2.default.any,
   clearing: _propTypes2.default.bool,
   cellRenderer: _propTypes2.default.func,
   valueRenderer: _propTypes2.default.func.isRequired,
@@ -325,7 +334,8 @@ DataCell.propTypes = {
   onDoubleClick: _propTypes2.default.func.isRequired,
   onContextMenu: _propTypes2.default.func.isRequired,
   onChange: _propTypes2.default.func.isRequired,
-  onRevert: _propTypes2.default.func.isRequired
+  onRevert: _propTypes2.default.func.isRequired,
+  onEdit: _propTypes2.default.func
 };
 
 DataCell.defaultProps = {

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -85,6 +85,7 @@ var DataSheet = function (_PureComponent) {
     _this.onDoubleClick = _this.onDoubleClick.bind(_this);
     _this.onContextMenu = _this.onContextMenu.bind(_this);
     _this.handleNavigate = _this.handleNavigate.bind(_this);
+    _this.handleEdit = _this.handleEdit.bind(_this);
     _this.handleKey = _this.handleKey.bind(_this).bind(_this);
     _this.handleCut = _this.handleCut.bind(_this);
     _this.handleCopy = _this.handleCopy.bind(_this);
@@ -343,6 +344,11 @@ var DataSheet = function (_PureComponent) {
       }
     }
   }, {
+    key: 'handleEdit',
+    value: function handleEdit(value) {
+      this.setState({ editValue: value });
+    }
+  }, {
     key: 'handleKey',
     value: function handleKey(e) {
       if (e.isPropagationStopped && e.isPropagationStopped()) {
@@ -440,77 +446,102 @@ var DataSheet = function (_PureComponent) {
       }
     }
   }, {
+    key: 'updateLocationSingleCell',
+    value: function updateLocationSingleCell(location) {
+      this._setState({
+        start: location,
+        end: location,
+        editing: {}
+      });
+    }
+  }, {
+    key: 'updateLocationMultipleCells',
+    value: function updateLocationMultipleCells(offsets) {
+      var _getState6 = this.getState(),
+          start = _getState6.start,
+          end = _getState6.end;
+
+      var data = this.props.data;
+
+      var oldStartLocation = { i: start.i, j: start.j };
+      var newEndLocation = { i: end.i + offsets.i, j: Math.min(data[0].length - 1, Math.max(0, end.j + offsets.j)) };
+      this._setState({
+        start: oldStartLocation,
+        end: newEndLocation,
+        editing: {}
+      });
+    }
+  }, {
+    key: 'searchForNextSelectablePos',
+    value: function searchForNextSelectablePos(isCellNavigable, data, start, offsets, jumpRow) {
+      var previousRow = function previousRow(location) {
+        return { i: location.i - 1, j: data[0].length - 1 };
+      };
+      var nextRow = function nextRow(location) {
+        return { i: location.i + 1, j: 0 };
+      };
+      var advanceOffset = function advanceOffset(location) {
+        return { i: location.i + offsets.i, j: location.j + offsets.j };
+      };
+      var isCellDefined = function isCellDefined(_ref3) {
+        var i = _ref3.i,
+            j = _ref3.j;
+        return data[i] && typeof data[i][j] !== 'undefined';
+      };
+
+      var newLocation = advanceOffset(start);
+
+      while (isCellDefined(newLocation) && !isCellNavigable(data[newLocation.i][newLocation.j], newLocation.i, newLocation.j)) {
+        newLocation = advanceOffset(newLocation);
+      }
+
+      if (!isCellDefined(newLocation)) {
+        if (!jumpRow) {
+          return null;
+        }
+        if (offsets.j < 0) {
+          newLocation = previousRow(newLocation);
+        } else {
+          newLocation = nextRow(newLocation);
+        }
+      }
+
+      if (isCellDefined(newLocation) && !isCellNavigable(data[newLocation.i][newLocation.j], newLocation.i, newLocation.j)) {
+        return this.searchForNextSelectablePos(isCellNavigable, data, newLocation, offsets, jumpRow);
+      } else if (isCellDefined(newLocation)) {
+        return newLocation;
+      } else {
+        return null;
+      }
+    }
+  }, {
     key: 'handleNavigate',
     value: function handleNavigate(e, offsets, jumpRow) {
-      var _this3 = this;
-
       if (offsets && (offsets.i || offsets.j)) {
-        var _getState6 = this.getState(),
-            start = _getState6.start,
-            end = _getState6.end;
-
         var data = this.props.data;
 
-        var oldStartLocation = { i: start.i, j: start.j };
-        var newEndLocation = { i: end.i + offsets.i, j: end.j + offsets.j };
+        var _getState7 = this.getState(),
+            start = _getState7.start;
 
-        var newLocation = { i: start.i + offsets.i, j: start.j + offsets.j
-          // check if we are allowed
-
-        };var updateLocation = function updateLocation() {
-          if (data[newLocation.i] && typeof data[newLocation.i][newLocation.j] !== 'undefined') {
-            _this3._setState({
-              start: e.shiftKey && !jumpRow ? oldStartLocation : newLocation,
-              end: e.shiftKey && !jumpRow ? newEndLocation : newLocation,
-              editing: {}
-            });
-            e.preventDefault();
-            return true;
-          }
-          return false;
+        var multiSelect = e.shiftKey && !jumpRow;
+        var isCellNavigable = this.props.isCellNavigable ? this.props.isCellNavigable : function () {
+          return true;
         };
 
-        if (this.props.isCellNavigable) {
-          var searchForNextSelectablePos = function searchForNextSelectablePos(data, newLocation, jumpRow, offsets) {
-            while (newLocation.i >= 0 && newLocation.i < data.length && newLocation.j < data[newLocation.i].length && newLocation.j >= 0 && !_this3.props.isCellNavigable(data[newLocation.i][newLocation.j], newLocation.i, newLocation.j, jumpRow)) {
-              newLocation = { i: newLocation.i, j: newLocation.j + offsets.j };
-            }
-            return newLocation;
-          };
-
-          newLocation = searchForNextSelectablePos(data, newLocation, jumpRow, offsets);
-          // did we jump over the border?
-          if (newLocation.j < 0 || newLocation.j >= data[newLocation.i].length) {
-            if (!jumpRow) {
-              return;
-            }
-            // we are allowed to go to the next row
-            if (offsets.j < 0) {
-              newLocation = { i: start.i - 1, j: data[0].length - 1 };
-            } else {
-              newLocation = { i: start.i + 1, j: 0 };
-            }
-
-            newLocation = searchForNextSelectablePos(data, newLocation, false, offsets);
+        if (multiSelect) {
+          this.updateLocationMultipleCells(offsets);
+        } else {
+          var newLocation = this.searchForNextSelectablePos(isCellNavigable, data, start, offsets, jumpRow);
+          if (newLocation) {
+            this.updateLocationSingleCell(newLocation);
           }
-          updateLocation();
-          return;
-        }
-
-        if (!updateLocation() && jumpRow) {
-          if (offsets.j < 0) {
-            newLocation = { i: start.i - 1, j: data[0].length - 1 };
-          } else {
-            newLocation = { i: start.i + 1, j: 0 };
-          }
-          updateLocation();
         }
       }
     }
   }, {
     key: 'handleComponentKey',
     value: function handleComponentKey(e) {
-      var _this4 = this;
+      var _this3 = this;
 
       // handles keyboard events when editing components
       var keyCode = e.which || e.keyCode;
@@ -529,16 +560,16 @@ var DataSheet = function (_PureComponent) {
           var func = this.onRevert; // ESCAPE_KEY
           if (keyCode === _keys.ENTER_KEY) {
             func = function func() {
-              return _this4.handleNavigate(e, { i: offset, j: 0 });
+              return _this3.handleNavigate(e, { i: offset, j: 0 });
             };
           } else if (keyCode === _keys.TAB_KEY) {
             func = function func() {
-              return _this4.handleNavigate(e, { i: 0, j: offset }, true);
+              return _this3.handleNavigate(e, { i: 0, j: offset }, true);
             };
           }
           // setTimeout makes sure that component is done handling the event before we take over
           setTimeout(function () {
-            func();_this4.dgDom && _this4.dgDom.focus();
+            func();_this3.dgDom && _this3.dgDom.focus();
           }, 1);
         }
       }
@@ -562,7 +593,7 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'onMouseDown',
     value: function onMouseDown(i, j, e) {
-      var _this5 = this;
+      var _this4 = this;
 
       var isNowEditingSameCell = !isEmpty(this.state.editing) && this.state.editing.i === i && this.state.editing.j === j;
       var editing = isEmpty(this.state.editing) || this.state.editing.i !== i || this.state.editing.j !== j ? {} : this.state.editing;
@@ -581,7 +612,7 @@ var DataSheet = function (_PureComponent) {
       if (isIE) {
         document.addEventListener('keydown', function (e) {
           if ((e.keyCode === 86 || e.which === 86) && e.ctrlKey) {
-            _this5.handlePaste(e);
+            _this4.handlePaste(e);
           }
         });
       }
@@ -628,18 +659,7 @@ var DataSheet = function (_PureComponent) {
     key: 'onRevert',
     value: function onRevert() {
       this._setState({ editing: {} });
-
-      const editor = this.dgDom;
-
-      if (!editor) return;
-
-      if (editor.setActive) {
-        editor.setActive(); // IE/Edge
-      } else {
-        editor.focus({
-          preventScroll: true // fix scroll to bottom if spreadsheet not all in viewport
-        }); // All other browsers
-      }
+      this.dgDom && this.dgDom.focus();
     }
   }, {
     key: 'componentDidUpdate',
@@ -656,9 +676,9 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'isSelected',
     value: function isSelected(i, j) {
-      var _getState7 = this.getState(),
-          start = _getState7.start,
-          end = _getState7.end;
+      var _getState8 = this.getState(),
+          start = _getState8.start,
+          end = _getState8.end;
 
       var posX = j >= start.j && j <= end.j;
       var negX = j <= start.j && j >= end.j;
@@ -680,7 +700,7 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'render',
     value: function render() {
-      var _this6 = this;
+      var _this5 = this;
 
       var _props6 = this.props,
           SheetRenderer = _props6.sheetRenderer,
@@ -701,7 +721,7 @@ var DataSheet = function (_PureComponent) {
       return _react2.default.createElement(
         'span',
         { ref: function ref(r) {
-            _this6.dgDom = r;
+            _this5.dgDom = r;
           }, tabIndex: '0', className: 'data-grid-container', onKeyDown: this.handleKey },
         _react2.default.createElement(
           SheetRenderer,
@@ -713,30 +733,34 @@ var DataSheet = function (_PureComponent) {
               RowRenderer,
               { key: keyFn ? keyFn(i) : i, row: i, cells: row },
               row.map(function (cell, j) {
-                return _react2.default.createElement(_DataCell2.default, {
+                var isEditing = _this5.isEditing(i, j);
+                return _react2.default.createElement(_DataCell2.default, _extends({
                   key: cell.key ? cell.key : i + '-' + j,
                   row: i,
                   col: j,
                   cell: cell,
                   forceEdit: forceEdit,
-                  onMouseDown: _this6.onMouseDown,
-                  onMouseOver: _this6.onMouseOver,
-                  onDoubleClick: _this6.onDoubleClick,
-                  onContextMenu: _this6.onContextMenu,
-                  onChange: _this6.onChange,
-                  onRevert: _this6.onRevert,
-                  onNavigate: _this6.handleKeyboardCellMovement,
-                  onKey: _this6.handleKey,
-                  selected: _this6.isSelected(i, j),
-                  editing: _this6.isEditing(i, j),
-                  clearing: _this6.isClearing(i, j),
+                  onMouseDown: _this5.onMouseDown,
+                  onMouseOver: _this5.onMouseOver,
+                  onDoubleClick: _this5.onDoubleClick,
+                  onContextMenu: _this5.onContextMenu,
+                  onChange: _this5.onChange,
+                  onRevert: _this5.onRevert,
+                  onNavigate: _this5.handleKeyboardCellMovement,
+                  onKey: _this5.handleKey,
+                  selected: _this5.isSelected(i, j),
+                  editing: isEditing,
+                  clearing: _this5.isClearing(i, j),
                   attributesRenderer: attributesRenderer,
                   cellRenderer: cellRenderer,
                   valueRenderer: valueRenderer,
                   dataRenderer: dataRenderer,
                   valueViewer: valueViewer,
-                  dataEditor: dataEditor
-                });
+                  dataEditor: dataEditor,
+                  editValue: _this5.state.editValue
+                }, isEditing ? {
+                  onEdit: _this5.handleEdit
+                } : {}));
               })
             );
           })

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -111,6 +111,7 @@ var DataSheet = function (_PureComponent) {
     _this.state = _this.defaultState;
 
     _this.removeAllListeners = _this.removeAllListeners.bind(_this);
+    _this.handleIEClipboardEvents = _this.handleIEClipboardEvents.bind(_this);
     return _this;
   }
 
@@ -122,7 +123,7 @@ var DataSheet = function (_PureComponent) {
       document.removeEventListener('cut', this.handleCut);
       document.removeEventListener('copy', this.handleCopy);
       document.removeEventListener('paste', this.handlePaste);
-      document.removeEventListener('keydown', this.handlePaste);
+      document.removeEventListener('keydown', this.handleIEClipboardEvents);
     }
   }, {
     key: 'componentDidMount',
@@ -206,6 +207,22 @@ var DataSheet = function (_PureComponent) {
       }
     }
   }, {
+    key: 'handleIEClipboardEvents',
+    value: function handleIEClipboardEvents(e) {
+      if (e.ctrlKey) {
+        if (e.keyCode === 67) {
+          // C - copy
+          this.handleCopy(e);
+        } else if (e.keyCode === 88) {
+          // X - cut
+          this.handleCut(e);
+        } else if (e.keyCode === 86 || e.which === 86) {
+          // P - patse
+          this.handlePaste(e);
+        }
+      }
+    }
+  }, {
     key: 'handleCopy',
     value: function handleCopy(e) {
       if (isEmpty(this.state.editing)) {
@@ -229,7 +246,11 @@ var DataSheet = function (_PureComponent) {
             return value;
           }).join('\t');
         }).join('\n');
-        e.clipboardData.setData('text/plain', text);
+        if (window.clipboardData && window.clipboardData.setData) {
+          window.clipboardData.setData('Text', text);
+        } else {
+          e.clipboardData.setData('text/plain', text);
+        }
       }
     }
   }, {
@@ -593,8 +614,6 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'onMouseDown',
     value: function onMouseDown(i, j, e) {
-      var _this4 = this;
-
       var isNowEditingSameCell = !isEmpty(this.state.editing) && this.state.editing.i === i && this.state.editing.j === j;
       var editing = isEmpty(this.state.editing) || this.state.editing.i !== i || this.state.editing.j !== j ? {} : this.state.editing;
 
@@ -610,11 +629,7 @@ var DataSheet = function (_PureComponent) {
       var isIE = /MSIE|Trident/.test(ua);
       // Listen for Ctrl + V in case of IE
       if (isIE) {
-        document.addEventListener('keydown', function (e) {
-          if ((e.keyCode === 86 || e.which === 86) && e.ctrlKey) {
-            _this4.handlePaste(e);
-          }
-        });
+        document.addEventListener('keydown', this.handleIEClipboardEvents);
       }
 
       // Keep listening to mouse if user releases the mouse (dragging outside)
@@ -700,7 +715,7 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'render',
     value: function render() {
-      var _this5 = this;
+      var _this4 = this;
 
       var _props6 = this.props,
           SheetRenderer = _props6.sheetRenderer,
@@ -721,7 +736,7 @@ var DataSheet = function (_PureComponent) {
       return _react2.default.createElement(
         'span',
         { ref: function ref(r) {
-            _this5.dgDom = r;
+            _this4.dgDom = r;
           }, tabIndex: '0', className: 'data-grid-container', onKeyDown: this.handleKey },
         _react2.default.createElement(
           SheetRenderer,
@@ -733,33 +748,33 @@ var DataSheet = function (_PureComponent) {
               RowRenderer,
               { key: keyFn ? keyFn(i) : i, row: i, cells: row },
               row.map(function (cell, j) {
-                var isEditing = _this5.isEditing(i, j);
+                var isEditing = _this4.isEditing(i, j);
                 return _react2.default.createElement(_DataCell2.default, _extends({
                   key: cell.key ? cell.key : i + '-' + j,
                   row: i,
                   col: j,
                   cell: cell,
                   forceEdit: forceEdit,
-                  onMouseDown: _this5.onMouseDown,
-                  onMouseOver: _this5.onMouseOver,
-                  onDoubleClick: _this5.onDoubleClick,
-                  onContextMenu: _this5.onContextMenu,
-                  onChange: _this5.onChange,
-                  onRevert: _this5.onRevert,
-                  onNavigate: _this5.handleKeyboardCellMovement,
-                  onKey: _this5.handleKey,
-                  selected: _this5.isSelected(i, j),
+                  onMouseDown: _this4.onMouseDown,
+                  onMouseOver: _this4.onMouseOver,
+                  onDoubleClick: _this4.onDoubleClick,
+                  onContextMenu: _this4.onContextMenu,
+                  onChange: _this4.onChange,
+                  onRevert: _this4.onRevert,
+                  onNavigate: _this4.handleKeyboardCellMovement,
+                  onKey: _this4.handleKey,
+                  selected: _this4.isSelected(i, j),
                   editing: isEditing,
-                  clearing: _this5.isClearing(i, j),
+                  clearing: _this4.isClearing(i, j),
                   attributesRenderer: attributesRenderer,
                   cellRenderer: cellRenderer,
                   valueRenderer: valueRenderer,
                   dataRenderer: dataRenderer,
                   valueViewer: valueViewer,
                   dataEditor: dataEditor,
-                  editValue: _this5.state.editValue
+                  editValue: _this4.state.editValue
                 }, isEditing ? {
-                  onEdit: _this5.handleEdit
+                  onEdit: _this4.handleEdit
                 } : {}));
               })
             );

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -60,6 +60,7 @@ export default class DataSheet extends PureComponent {
     this.state = this.defaultState
 
     this.removeAllListeners = this.removeAllListeners.bind(this)
+    this.handleIEClipboardEvents = this.handleIEClipboardEvents.bind(this)
   }
 
   removeAllListeners () {
@@ -68,7 +69,7 @@ export default class DataSheet extends PureComponent {
     document.removeEventListener('cut', this.handleCut)
     document.removeEventListener('copy', this.handleCopy)
     document.removeEventListener('paste', this.handlePaste)
-    document.removeEventListener('keydown', this.handlePaste)
+    document.removeEventListener('keydown', this.handleIEClipboardEvents)
   }
 
   componentDidMount () {
@@ -132,6 +133,21 @@ export default class DataSheet extends PureComponent {
     }
   }
 
+  handleIEClipboardEvents(e) {
+    if (e.ctrlKey) {
+      if (e.keyCode === 67) {
+        // C - copy
+        this.handleCopy(e)
+      } else if (e.keyCode === 88) {
+        // X - cut
+        this.handleCut(e)
+      } else if (e.keyCode === 86 || e.which === 86) {
+        // P - patse
+        this.handlePaste(e)
+      }
+    }
+  }
+
   handleCopy (e) {
     if (isEmpty(this.state.editing)) {
       e.preventDefault()
@@ -148,7 +164,11 @@ export default class DataSheet extends PureComponent {
           return value
         }).join('\t')
       ).join('\n')
-      e.clipboardData.setData('text/plain', text)
+      if (window.clipboardData && window.clipboardData.setData) {
+        window.clipboardData.setData('Text', text)
+      } else {
+        e.clipboardData.setData('text/plain', text)
+      }
     }
   }
 
@@ -466,11 +486,7 @@ export default class DataSheet extends PureComponent {
     var isIE = /MSIE|Trident/.test(ua)
     // Listen for Ctrl + V in case of IE
     if (isIE) {
-      document.addEventListener('keydown', (e) => {
-        if ((e.keyCode === 86 || e.which === 86) && e.ctrlKey) {
-          this.handlePaste(e)
-        }
-      })
+      document.addEventListener('keydown', this.handleIEClipboardEvents)
     }
 
     // Keep listening to mouse if user releases the mouse (dragging outside)


### PR DESCRIPTION
Version 1.4.1, features Copy/Cut/Patse on IE11 didn't work
While fix it I found another problem has a bug when handle mousedown for IE11:
event register: 
`
  if (isIE) {
      document.addEventListener('keydown', (e) => {
        if ((e.keyCode === 86 || e.which === 86) && e.ctrlKey) {
          this.handlePaste(e)
        }
      })
    }
`
But event unregister is incorrect:
`
document.removeEventListener('keydown', this.handlePaste)
`
This will result memory leak when component unmount!