### PR TITLE
Add disablePageClick Prop

### DIFF
--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -186,6 +186,7 @@ var DataSheet = function (_PureComponent) {
   }, {
     key: 'pageClick',
     value: function pageClick(e) {
+      if (this.props.disablePageClick) return;
       var element = this.dgDom;
       if (!element.contains(e.target)) {
         this.setState(this.defaultState);
@@ -812,6 +813,7 @@ exports.default = DataSheet;
 DataSheet.propTypes = {
   data: _propTypes2.default.array.isRequired,
   className: _propTypes2.default.string,
+  disablePageClick: _propTypes2.default.bool,
   overflow: _propTypes2.default.oneOf(['wrap', 'nowrap', 'clip']),
   onChange: _propTypes2.default.func,
   onCellsChanged: _propTypes2.default.func,

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -129,6 +129,7 @@ export default class DataSheet extends PureComponent {
   }
 
   pageClick(e) {
+    if(this.props.disablePageClick) return;
     const element = this.dgDom;
     if (!element.contains(e.target)) {
       this.setState(this.defaultState);
@@ -705,6 +706,7 @@ export default class DataSheet extends PureComponent {
 DataSheet.propTypes = {
   data: PropTypes.array.isRequired,
   className: PropTypes.string,
+  disablePageClick: PropTypes.bool,
   overflow: PropTypes.oneOf(['wrap', 'nowrap', 'clip']),
   onChange: PropTypes.func,
   onCellsChanged: PropTypes.func,


### PR DESCRIPTION
This allows disabling the `pageClick` handler.

Use case: I have a dataEditor that is a portal (full screen modal) outside the react render tree. That means clicking anything in the modal will cancel editing, because pageClick's `contains` check will always fail, but that is not desired. This props allows me to disable the default "click other things to finish editing" behaviour, and I can use `onCommit` and `onRevert` manually.

This change does the trick for me but I think it is not very clean/elegant. Perhaps a cleaner option is to add a "manualDismissEditor" option to a cell.