### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "pretty-quick": "^2.0.1"
   },
   "peerDependencies": {
-    "prop-types": ">=16",
+    "prop-types": ">=15",
     "react": ">=16",
     "react-dom": ">=16"
   },


### PR DESCRIPTION
Update prop-types peer dependency to version range that actually exists in this universe.

prop-types doesn't have >=16 version https://www.npmjs.com/package/prop-types

This blows up npm v7 dependency resolver.