### PR TITLE
Prevent table from shifting window scroll position

### DIFF
--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -519,7 +519,7 @@ export default class DataSheet extends PureComponent {
         // setTimeout makes sure that component is done handling the event before we take over
         setTimeout(() => {
           func();
-          this.dgDom && this.dgDom.focus();
+          this.dgDom && this.dgDom.focus({ preventScroll: true });
         }, 1);
       }
     }
@@ -600,7 +600,7 @@ export default class DataSheet extends PureComponent {
 
   onRevert() {
     this._setState({ editing: {} });
-    this.dgDom && this.dgDom.focus();
+    this.dgDom && this.dgDom.focus({ preventScroll: true });
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
### Problem 

Issue: #147 

When focusing on the table for keyboard usage, the focus event steals the windows scroll position, this is only a problem if the table is larger than the screen it is on.


### Solution

By setting prevent scroll to true, this wont happen.

### Considerations

There is varying browser implementation for this, but otherwise it is very stable. The main thing to consider is that browsers that don't implement this functionality yet, wont break or throw any errors. They just ignore the boolean flag