### PR TITLE
TypeScript: added onKeyUp handler to CellRendererProps

### DIFF
--- a/types/react-datasheet.d.ts
+++ b/types/react-datasheet.d.ts
@@ -1,4 +1,4 @@
-import { Component, ReactNode, MouseEventHandler} from "react";
+import { Component, ReactNode, KeyboardEventHandler, MouseEventHandler } from "react";
 
 declare namespace ReactDataSheet {
     /** The cell object is what gets passed to the callbacks and events, and contains the basic information about what to show in each cell. You should extend this interface to build a place to store your data.
@@ -187,6 +187,8 @@ declare namespace ReactDataSheet {
         onDoubleClick: MouseEventHandler<HTMLElement>;
         /** Event handler: to launch default content-menu handling. You can safely ignore this handler if you want to provide your own content menu handling. */
         onContextMenu: MouseEventHandler<HTMLElement>;
+        /** Event handler: important for cell selection behavior */
+        onKeyUp: KeyboardEventHandler<HTMLElement>;
         /** The regular react props.children. You must render {props.children} within your custom renderer or you won't your cell's data. */
         children: ReactNode;
     }


### PR DESCRIPTION
# Why

When trying to override cellRenderer you need to pass props to <td>:

``` 
<td
    onMouseDown={props.onMouseDown}
    onMouseOver={props.onMouseOver}
    onDoubleClick={props.onDoubleClick}
    onContextMenu={props.onContextMenu}
    onKeyUp={props.onKeyUp}
>
    {props.children}
</td>
```

However the type for CellRendererProps is missing onKeyUp and TypeScript shows an error that it doesn't exist on props.

# How

Added onKeyUp to CellRendererProps.
Keyboard navigation is now possible on a custom cellRenderer in TypeScript
