### PR TITLE
feat: expose selecting prop

### DIFF
--- a/lib/DataCell.js
+++ b/lib/DataCell.js
@@ -365,6 +365,7 @@ var DataCell = (function (_PureComponent) {
           valueViewer = _props7.valueViewer,
           attributesRenderer = _props7.attributesRenderer,
           selected = _props7.selected,
+          selecting = _props7.selecting,
           editing = _props7.editing,
           onKeyUp = _props7.onKeyUp;
         var updated = this.state.updated;
@@ -395,6 +396,7 @@ var DataCell = (function (_PureComponent) {
             col: col,
             cell: cell,
             selected: selected,
+            selecting: selecting,
             editing: editing,
             updated: updated,
             attributesRenderer: attributesRenderer,
@@ -423,6 +425,7 @@ DataCell.propTypes = {
   cell: _propTypes2.default.shape(_CellShape2.default).isRequired,
   forceEdit: _propTypes2.default.bool,
   selected: _propTypes2.default.bool,
+  selecting: _propTypes2.default.bool,
   editing: _propTypes2.default.bool,
   editValue: _propTypes2.default.any,
   clearing: _propTypes2.default.bool,

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -172,9 +172,8 @@ var DataSheet = (function (_PureComponent) {
     _this.isClearing = _this.isClearing.bind(_this);
     _this.handleComponentKey = _this.handleComponentKey.bind(_this);
 
-    _this.handleKeyboardCellMovement = _this.handleKeyboardCellMovement.bind(
-      _this,
-    );
+    _this.handleKeyboardCellMovement =
+      _this.handleKeyboardCellMovement.bind(_this);
 
     _this.defaultState = {
       start: {},
@@ -514,12 +513,8 @@ var DataSheet = (function (_PureComponent) {
         var currentCell = !noCellsSelected && this.props.data[start.i][start.j];
         var equationKeysPressed =
           [
-            187 /* equal */,
-            189 /* substract */,
-            190 /* period */,
-            107 /* add */,
-            109 /* decimal point */,
-            110,
+            187 /* equal */, 189 /* substract */, 190 /* period */,
+            107 /* add */, 109 /* decimal point */, 110,
           ].indexOf(keyCode) > -1;
 
         if (noCellsSelected || ctrlKeyPressed) {
@@ -1002,6 +997,7 @@ var DataSheet = (function (_PureComponent) {
                         onNavigate: _this4.handleKeyboardCellMovement,
                         onKey: _this4.handleKey,
                         selected: _this4.isSelected(i, j),
+                        selecting: _this4.state.selecting,
                         editing: isEditing,
                         clearing: _this4.isClearing(i, j),
                         attributesRenderer: attributesRenderer,

--- a/src/DataCell.js
+++ b/src/DataCell.js
@@ -192,6 +192,7 @@ export default class DataCell extends PureComponent {
       valueViewer,
       attributesRenderer,
       selected,
+      selecting,
       editing,
       onKeyUp,
     } = this.props;
@@ -220,6 +221,7 @@ export default class DataCell extends PureComponent {
         col={col}
         cell={cell}
         selected={selected}
+        selecting={selecting}
         editing={editing}
         updated={updated}
         attributesRenderer={attributesRenderer}
@@ -243,6 +245,7 @@ DataCell.propTypes = {
   cell: PropTypes.shape(CellShape).isRequired,
   forceEdit: PropTypes.bool,
   selected: PropTypes.bool,
+  selecting: PropTypes.bool,
   editing: PropTypes.bool,
   editValue: PropTypes.any,
   clearing: PropTypes.bool,

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -54,9 +54,8 @@ export default class DataSheet extends PureComponent {
     this.isClearing = this.isClearing.bind(this);
     this.handleComponentKey = this.handleComponentKey.bind(this);
 
-    this.handleKeyboardCellMovement = this.handleKeyboardCellMovement.bind(
-      this,
-    );
+    this.handleKeyboardCellMovement =
+      this.handleKeyboardCellMovement.bind(this);
 
     this.defaultState = {
       start: {},
@@ -319,12 +318,8 @@ export default class DataSheet extends PureComponent {
     const currentCell = !noCellsSelected && this.props.data[start.i][start.j];
     const equationKeysPressed =
       [
-        187 /* equal */,
-        189 /* substract */,
-        190 /* period */,
-        107 /* add */,
-        109 /* decimal point */,
-        110,
+        187 /* equal */, 189 /* substract */, 190 /* period */, 107 /* add */,
+        109 /* decimal point */, 110,
       ].indexOf(keyCode) > -1;
 
     if (noCellsSelected || ctrlKeyPressed) {
@@ -684,6 +679,7 @@ export default class DataSheet extends PureComponent {
                     onNavigate={this.handleKeyboardCellMovement}
                     onKey={this.handleKey}
                     selected={this.isSelected(i, j)}
+                    selecting={this.state.selecting}
                     editing={isEditing}
                     clearing={this.isClearing(i, j)}
                     attributesRenderer={attributesRenderer}

--- a/types/react-datasheet.d.ts
+++ b/types/react-datasheet.d.ts
@@ -173,6 +173,8 @@ declare namespace ReactDataSheet {
         style: object | null | undefined;
         /** Is the cell currently selected */
         selected: boolean;
+        /** Is selecting in progress */
+        selecting: boolean;
         /** Is the cell currently being edited */
         editing: boolean;
         /** Was the cell recently updated */


### PR DESCRIPTION
This PR exposes selecting prop to Cell component

Use case: I need to implement scroll to selected cell when navigating. OnCellsChanged props is not suitable for the task since it doesn't have access to cell's refs. Without this prop my scrollToCell logic is executed on every selection change which results in a bad UX. 