### PR TITLE
fix: shift+click when selection is controlled

### DIFF
--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -814,20 +814,21 @@ var DataSheet = (function (_PureComponent) {
     {
       key: 'onMouseDown',
       value: function onMouseDown(i, j, e) {
+        var state = this.getState();
         var isNowEditingSameCell =
-          !isEmpty(this.state.editing) &&
-          this.state.editing.i === i &&
-          this.state.editing.j === j;
+          !isEmpty(state.editing) &&
+          state.editing.i === i &&
+          state.editing.j === j;
         var editing =
-          isEmpty(this.state.editing) ||
-          this.state.editing.i !== i ||
-          this.state.editing.j !== j
+          isEmpty(state.editing) ||
+          state.editing.i !== i ||
+          state.editing.j !== j
             ? {}
-            : this.state.editing;
+            : state.editing;
 
         this._setState({
           selecting: !isNowEditingSameCell,
-          start: e.shiftKey ? this.state.start : { i: i, j: j },
+          start: e.shiftKey ? state.start : { i: i, j: j },
           end: { i: i, j: j },
           editing: editing,
           forceEdit: !!isNowEditingSameCell,

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -540,20 +540,17 @@ export default class DataSheet extends PureComponent {
   }
 
   onMouseDown(i, j, e) {
+    const state = this.getState();
     const isNowEditingSameCell =
-      !isEmpty(this.state.editing) &&
-      this.state.editing.i === i &&
-      this.state.editing.j === j;
+      !isEmpty(state.editing) && state.editing.i === i && state.editing.j === j;
     let editing =
-      isEmpty(this.state.editing) ||
-      this.state.editing.i !== i ||
-      this.state.editing.j !== j
+      isEmpty(state.editing) || state.editing.i !== i || state.editing.j !== j
         ? {}
-        : this.state.editing;
+        : state.editing;
 
     this._setState({
       selecting: !isNowEditingSameCell,
-      start: e.shiftKey ? this.state.start : { i, j },
+      start: e.shiftKey ? state.start : { i, j },
       end: { i, j },
       editing: editing,
       forceEdit: !!isNowEditingSameCell,


### PR DESCRIPTION
Selecting multiple cells with Shift+Click is not working when selection is controlled externally.

I found that Datasheet wasn't using the right selected state in the mouse handler.
