### PR TITLE
Immediate focus of container after a commit can lead to undesirable behaviours

### DIFF
--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -887,8 +887,13 @@ var DataSheet = (function (_PureComponent) {
     {
       key: 'onRevert',
       value: function onRevert() {
+        var _this4 = this;
+
         this._setState({ editing: {} });
-        this.dgDom && this.dgDom.focus({ preventScroll: true });
+        // setTimeout makes sure that component is done handling the new state before we take over
+        setTimeout(function () {
+          _this4.dgDom && _this4.dgDom.focus({ preventScroll: true });
+        }, 1);
       },
     },
     {
@@ -941,7 +946,7 @@ var DataSheet = (function (_PureComponent) {
     {
       key: 'render',
       value: function render() {
-        var _this4 = this;
+        var _this5 = this;
 
         var _props6 = this.props,
           SheetRenderer = _props6.sheetRenderer,
@@ -962,7 +967,7 @@ var DataSheet = (function (_PureComponent) {
           'span',
           {
             ref: function ref(r) {
-              _this4.dgDom = r;
+              _this5.dgDom = r;
             },
             tabIndex: '0',
             className: 'data-grid-container',
@@ -983,7 +988,7 @@ var DataSheet = (function (_PureComponent) {
                 RowRenderer,
                 { key: keyFn ? keyFn(i) : i, row: i, cells: row },
                 row.map(function (cell, j) {
-                  var isEditing = _this4.isEditing(i, j);
+                  var isEditing = _this5.isEditing(i, j);
                   return _react2.default.createElement(
                     _DataCell2.default,
                     _extends(
@@ -993,17 +998,17 @@ var DataSheet = (function (_PureComponent) {
                         col: j,
                         cell: cell,
                         forceEdit: false,
-                        onMouseDown: _this4.onMouseDown,
-                        onMouseOver: _this4.onMouseOver,
-                        onDoubleClick: _this4.onDoubleClick,
-                        onContextMenu: _this4.onContextMenu,
-                        onChange: _this4.onChange,
-                        onRevert: _this4.onRevert,
-                        onNavigate: _this4.handleKeyboardCellMovement,
-                        onKey: _this4.handleKey,
-                        selected: _this4.isSelected(i, j),
+                        onMouseDown: _this5.onMouseDown,
+                        onMouseOver: _this5.onMouseOver,
+                        onDoubleClick: _this5.onDoubleClick,
+                        onContextMenu: _this5.onContextMenu,
+                        onChange: _this5.onChange,
+                        onRevert: _this5.onRevert,
+                        onNavigate: _this5.handleKeyboardCellMovement,
+                        onKey: _this5.handleKey,
+                        selected: _this5.isSelected(i, j),
                         editing: isEditing,
-                        clearing: _this4.isClearing(i, j),
+                        clearing: _this5.isClearing(i, j),
                         attributesRenderer: attributesRenderer,
                         cellRenderer: cellRenderer,
                         valueRenderer: valueRenderer,

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -600,7 +600,10 @@ export default class DataSheet extends PureComponent {
 
   onRevert() {
     this._setState({ editing: {} });
-    this.dgDom && this.dgDom.focus({ preventScroll: true });
+    // setTimeout makes sure that component is done handling the new state before we take over
+    setTimeout(() => {
+      this.dgDom && this.dgDom.focus({ preventScroll: true });
+    }, 1);
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
When commiting in a DataEditor, the immediate focus of the container triggers onBlur events before the new render.

I have an onBlur handler in my custom DataEditor, and I was expected after a commit the component to be unmount instead (it is, but after the onBlur).

I reused the same method as here: https://github.com/Shato-io/react-datasheet/blob/33e0a8cebd130f47191d24c18a9cede40f00569e/src/DataSheet.js#L519